### PR TITLE
Add "reorganise" and "restructure" to verbs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mristin/opinionated-commit-message",
-  "version": "1.0.1",
+  "version": "1.0.1post1",
   "description": "Github Action to check commit messages according to an opinionated style",
   "keywords": [
     "github",

--- a/src/mostFrequentEnglishVerbs.ts
+++ b/src/mostFrequentEnglishVerbs.ts
@@ -408,6 +408,7 @@ export const SET = new Set([
   'operate',
   'order',
   'organise',
+  'organize',
   'owe',
   'own',
   'paint',
@@ -655,5 +656,8 @@ export const SET = new Set([
 
   // Programming-specific verbs
   'rewrite',
-  'refactor'
+  'refactor',
+  'reorganise',
+  'reorganize',
+  'restructure'
 ]);


### PR DESCRIPTION
This extends the list of acceptable verbs with two verbs ("reorganise"
and "restrcture") which are commonly used in the context of programming.