### PR TITLE
Tolerate hash code in subject

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mristin/opinionated-commit-message",
-  "version": "1.0.2",
+  "version": "1.0.2post1",
   "description": "Github Action to check commit messages according to an opinionated style",
   "keywords": [
     "github",

--- a/src/__tests__/inspection.test.ts
+++ b/src/__tests__/inspection.test.ts
@@ -11,6 +11,17 @@ it('reports no errors on correct message.', () => {
   expect(errors).toEqual([]);
 });
 
+it('tolerates hash code in the subject.', () => {
+  const message =
+    'Unify all license files to LICENSE.txt naming (#43)\n' +
+    '\n' +
+    'The license files naming was inconsistent (`LICENSE.TXT` and \n' +
+    '`LICENSE.txt`). This makes them all uniform (`LICENSE.txt`).';
+
+  const errors = inspection.check(message);
+  expect(errors).toEqual([]);
+});
+
 it('reports too few lines.', () => {
   const message = 'Change SomeClass to OtherClass';
   const errors = inspection.check(message);

--- a/src/inspection.ts
+++ b/src/inspection.ts
@@ -36,22 +36,35 @@ function splitSubjectBody(message: string): MaybeSubjectBody {
 
 const capitalizedWordRe = new RegExp('^([A-Z][a-z]*)[^a-zA-Z]');
 
+const suffixHashCodeRe = new RegExp('\\s?\\(\\s*#[a-zA-Z_0-9]+\\s*\\)$');
+
 function checkSubject(subject: string): string[] {
   const errors: string[] = [];
 
-  if (subject.length > 50) {
+  // Tolerate the hash code referring, e.g., to a pull request.
+  // These hash codes are usually added automatically by Github and
+  // similar services.
+  const subjectWoCode = subject.replace(suffixHashCodeRe, '');
+
+  if (subjectWoCode.length > 50) {
     errors.push(
       `The subject exceeds the limit of 50 characters, got: ${subject.length}`
     );
   }
 
-  const match = capitalizedWordRe.exec(subject);
+  const match = capitalizedWordRe.exec(subjectWoCode);
 
   if (!match) {
     errors.push(
       'The subject must start with a capitalized verb (e.g., "Change").'
     );
   } else {
+    if (match.length < 2) {
+      throw Error(
+        'Expected at least one group to match the first capitalized word, ' +
+          'but got none.'
+      );
+    }
     const word = match[1];
     if (!mostFrequentEnglishVerbs.SET.has(word.toLowerCase())) {
       errors.push(
@@ -64,7 +77,7 @@ function checkSubject(subject: string): string[] {
     }
   }
 
-  if (subject.endsWith('.')) {
+  if (subjectWoCode.endsWith('.')) {
     errors.push("The subject must not end with a dot ('.').");
   }
 


### PR DESCRIPTION
Github and similar services often add a (hash) code referring to the
pull request in the commit message *after* the squash & merge.

This change adds tolerance for the code so that the commit messages also
pass the test *after* the merge.