### PR TITLE
Add `reformat` and `update` verbs

### DIFF
--- a/src/mostFrequentEnglishVerbs.ts
+++ b/src/mostFrequentEnglishVerbs.ts
@@ -663,5 +663,7 @@ export const SET = new Set([
   'unify',
   'reword',
   'rephrase',
-  'upgrade'
+  'upgrade',
+  'reformat',
+  'update'
 ]);


### PR DESCRIPTION
This adds verbs `reformat` and `update` to the list after fixing the 
lines of aasx-package-explorer to 120 characters.