### PR TITLE
Inform user about OK messages

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -4467,6 +4467,9 @@ function run() {
                 const repr = represent.formatErrors(message, messageIndex, errors);
                 parts.push(repr);
             }
+            else {
+                core.info(`The message is OK:\n---\n${message}\n---`);
+            }
         }
         const errorMessage = parts.join('\n');
         if (errorMessage.length > 0) {

--- a/src/mainImpl.ts
+++ b/src/mainImpl.ts
@@ -24,6 +24,8 @@ export function run(): void {
         );
 
         parts.push(repr);
+      } else {
+        core.info(`The message is OK:\n---\n${message}\n---`);
       }
     }
 


### PR DESCRIPTION
There was no information shown to user if the message was OK which
is sometimes misleading and prevents users from verifying the
behvaior of the action.

This displays a message to the user both on invalid and valid messages.