### PR TITLE
Test messages of exactly 72 characters

### DIFF
--- a/src/__tests__/inspection.test.ts
+++ b/src/__tests__/inspection.test.ts
@@ -94,6 +94,25 @@ it('reports too long a body line.', () => {
   ]);
 });
 
+it('accepts a body line of exactly 72 characters', () => {
+  const message =
+    'Do something\n' +
+    '\n' +
+    'This patch fixes a typo in the readme file where this project was called\n' +
+    'dead-csharp instead of doctest-csharp.\n' +
+    '1234567890' +
+    '1234567890' +
+    '1234567890' +
+    '1234567890' +
+    '1234567890' +
+    '1234567890' +
+    '1234567890' +
+    '12';
+
+  const errors = inspection.check(message);
+  expect(errors).toEqual([]);
+});
+
 it('reports body that does not start with a word.', () => {
   const message = 'Change SomeClass to OtherClass\n\n* Do something';
 


### PR DESCRIPTION
This adds a test case for inspection of messages of exactly 72
characters in length.