### PR TITLE
Introduce npm script `fix`

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "format": "prettier --write **/*.ts",
     "format-check": "prettier --check **/*.ts",
     "lint": "eslint src/**/*.ts",
+    "fix": "eslint src/**/*.ts --fix",
     "pack": "ncc build",
     "test": "jest",
     "all": "npm run build && npm run format && npm run lint && npm run pack && npm test"


### PR DESCRIPTION
This gives a shortcut to running eslint in fix mode.