### PR TITLE
Ignore merge messages

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -633,8 +633,13 @@ function checkBody(subject, bodyLines) {
     }
     return errors;
 }
+const mergeMessageRe = new RegExp("^Merge branch '[^\\000-\\037\\177 ~^:?*[]+' " +
+    'into [^\\000-\\037\\177 ~^:?*[]+$');
 function check(message) {
     const errors = [];
+    if (mergeMessageRe.test(message)) {
+        return errors;
+    }
     const maybeSubjectBody = splitSubjectBody(message);
     if (maybeSubjectBody.errors.length > 0) {
         errors.push(...maybeSubjectBody.errors);

--- a/src/__tests__/inspection.test.ts
+++ b/src/__tests__/inspection.test.ts
@@ -133,3 +133,10 @@ it('reports duplicate starting word in subject and body.', () => {
     'The first word of the subject must not match the first word of the body.'
   ]);
 });
+
+it('ignores merge messages.', () => {
+  const message = "Merge branch 'V20DataModel' into miho/Conform-to-spec";
+
+  const errors = inspection.check(message);
+  expect(errors).toEqual([]);
+});

--- a/src/inspection.ts
+++ b/src/inspection.ts
@@ -131,8 +131,17 @@ function checkBody(subject: string, bodyLines: string[]): string[] {
   return errors;
 }
 
+const mergeMessageRe = new RegExp(
+  "^Merge branch '[^\\000-\\037\\177 ~^:?*[]+' " +
+    'into [^\\000-\\037\\177 ~^:?*[]+$'
+);
+
 export function check(message: string): string[] {
   const errors: string[] = [];
+
+  if (mergeMessageRe.test(message)) {
+    return errors;
+  }
 
   const maybeSubjectBody = splitSubjectBody(message);
   if (maybeSubjectBody.errors.length > 0) {


### PR DESCRIPTION
Merge commit messages are automatically generated by Git.
There is little point to rewrite them by the developer, so we ignore
them although they do not conform to the rules.