### PR TITLE
Relax checks on body messages

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -611,14 +611,12 @@ function checkBody(subject, bodyLines) {
         if (line.length > 72) {
             errors.push(`The line ${i + 3} of the message (line ${i + 1} of the body) ` +
                 'exceeds the limit of 72 characters. ' +
-                `The line contains ${line.length} characters: ${JSON.stringify(line)}`);
+                `The line contains ${line.length} characters: ` +
+                `${JSON.stringify(line)}.`);
         }
     }
     const bodyFirstWordMatch = capitalizedWordRe.exec(bodyLines[0]);
-    if (!bodyFirstWordMatch) {
-        errors.push('The body must start with a capitalized word.');
-    }
-    else {
+    if (bodyFirstWordMatch) {
         const bodyFirstWord = bodyFirstWordMatch[1];
         const subjectFirstWordMatch = capitalizedWordRe.exec(subject);
         if (subjectFirstWordMatch !== undefined &&
@@ -626,7 +624,9 @@ function checkBody(subject, bodyLines) {
             subjectFirstWordMatch.length > 0) {
             const subjectFirstWord = subjectFirstWordMatch[1];
             if (subjectFirstWord.toLowerCase() === bodyFirstWord.toLowerCase()) {
-                errors.push('The first word of the subject must not match ' +
+                errors.push('The first word of the subject ' +
+                    `(${JSON.stringify(subjectFirstWord)}) ` +
+                    'must not match ' +
                     'the first word of the body.');
             }
         }
@@ -8612,7 +8612,8 @@ exports.SET = new Set([
     'simplify',
     'extract',
     'downgrade',
-    'clarify'
+    'clarify',
+    'relax'
 ]);
 
 

--- a/src/__tests__/inspection.test.ts
+++ b/src/__tests__/inspection.test.ts
@@ -92,7 +92,7 @@ it('reports too long a body line.', () => {
     'The line 3 of the message (line 1 of the body) exceeds the limit of ' +
       '72 characters. The line contains 97 characters: ' +
       '"This replaces the SomeClass with OtherClass in all of the module since ' +
-      'Some class was deprecated."'
+      'Some class was deprecated.".'
   ]);
 });
 
@@ -115,11 +115,11 @@ it('accepts a body line of exactly 72 characters', () => {
   expect(errors).toEqual([]);
 });
 
-it('reports body that does not start with a word.', () => {
+it('accepts body that does not start with a word.', () => {
   const message = 'Change SomeClass to OtherClass\n\n* Do something';
 
   const errors = inspection.check(message);
-  expect(errors).toEqual(['The body must start with a capitalized word.']);
+  expect(errors).toEqual([]);
 });
 
 it('reports duplicate starting word in subject and body.', () => {
@@ -130,7 +130,8 @@ it('reports duplicate starting word in subject and body.', () => {
 
   const errors = inspection.check(message);
   expect(errors).toEqual([
-    'The first word of the subject must not match the first word of the body.'
+    'The first word of the subject ("Change") must not match ' +
+      'the first word of the body.'
   ]);
 });
 

--- a/src/__tests__/main.test.ts
+++ b/src/__tests__/main.test.ts
@@ -24,7 +24,7 @@ it('formats properly no error message.', () => {
   expect(mockSetFailed.mock.calls).toEqual([]);
 });
 
-it('formats properly a single error message.', () => {
+it('formats properly errors on a single message.', () => {
   (commitMessages.retrieve as any).mockImplementation(() => [
     'SomeClass to OtherClass\n\nSomeClass with OtherClass'
   ]);
@@ -37,7 +37,6 @@ it('formats properly a single error message.', () => {
     [
       'The message 1 is invalid:\n' +
         '* The subject must start with a capitalized verb (e.g., "Change").\n' +
-        '* The body must start with a capitalized word.\n' +
         'The original message was:\n' +
         'SomeClass to OtherClass\n' +
         '\n' +
@@ -46,9 +45,9 @@ it('formats properly a single error message.', () => {
   ]);
 });
 
-it('formats properly two error messages.', () => {
+it('formats properly errors on two messages.', () => {
   (commitMessages.retrieve as any).mockImplementation(() => [
-    'SomeClass to OtherClass\n\nSomeClass with OtherClass',
+    `SomeClass to OtherClass\n\n${'A'.repeat(73)}`,
     'Change other subject\n\nChange body'
   ]);
 
@@ -59,21 +58,23 @@ it('formats properly two error messages.', () => {
 
   expect(mockSetFailed.mock.calls).toEqual([
     [
-      'The message 1 is invalid:\n' +
+      `${'The message 1 is invalid:\n' +
         '* The subject must start with a capitalized verb (e.g., "Change").\n' +
-        '* The body must start with a capitalized word.\n' +
-        'The original message was:\n' +
-        'SomeClass to OtherClass\n' +
-        '\n' +
-        'SomeClass with OtherClass\n' +
-        '\n' +
-        'The message 2 is invalid:\n' +
-        '* The first word of the subject must not match ' +
-        'the first word of the body.\n' +
-        'The original message was:\n' +
-        'Change other subject\n' +
-        '\n' +
-        'Change body\n'
+        '* The line 3 of the message (line 1 of the body) exceeds ' +
+        'the limit of 72 characters. The line contains 73 characters: "'}${'A'.repeat(
+        73
+      )}".\n` +
+        `The original message was:\n` +
+        `SomeClass to OtherClass\n` +
+        `\n${'A'.repeat(73)}\n` +
+        `\n` +
+        `The message 2 is invalid:\n` +
+        `* The first word of the subject ("Change") must not match ` +
+        `the first word of the body.\n` +
+        `The original message was:\n` +
+        `Change other subject\n` +
+        `\n` +
+        `Change body\n`
     ]
   ]);
 });

--- a/src/inspection.ts
+++ b/src/inspection.ts
@@ -100,16 +100,15 @@ function checkBody(subject: string, bodyLines: string[]): string[] {
       errors.push(
         `The line ${i + 3} of the message (line ${i + 1} of the body) ` +
           'exceeds the limit of 72 characters. ' +
-          `The line contains ${line.length} characters: ${JSON.stringify(line)}`
+          `The line contains ${line.length} characters: ` +
+          `${JSON.stringify(line)}.`
       );
     }
   }
 
   const bodyFirstWordMatch = capitalizedWordRe.exec(bodyLines[0]);
 
-  if (!bodyFirstWordMatch) {
-    errors.push('The body must start with a capitalized word.');
-  } else {
+  if (bodyFirstWordMatch) {
     const bodyFirstWord = bodyFirstWordMatch[1];
 
     const subjectFirstWordMatch = capitalizedWordRe.exec(subject);
@@ -121,7 +120,9 @@ function checkBody(subject: string, bodyLines: string[]): string[] {
       const subjectFirstWord = subjectFirstWordMatch[1];
       if (subjectFirstWord.toLowerCase() === bodyFirstWord.toLowerCase()) {
         errors.push(
-          'The first word of the subject must not match ' +
+          'The first word of the subject ' +
+            `(${JSON.stringify(subjectFirstWord)}) ` +
+            'must not match ' +
             'the first word of the body.'
         );
       }

--- a/src/mostFrequentEnglishVerbs.ts
+++ b/src/mostFrequentEnglishVerbs.ts
@@ -678,5 +678,6 @@ export const SET = new Set([
   'simplify',
   'extract',
   'downgrade',
-  'clarify'
+  'clarify',
+  'relax'
 ]);


### PR DESCRIPTION
It is too strict to require the body to start with a capitalied word.
Oftentimes, the body lists the changes as bullet points or uses
a similar styling.

For an example, this fixes issue #29.