### PR TITLE
Add "delete" and "erase"

### DIFF
--- a/src/mostFrequentEnglishVerbs.ts
+++ b/src/mostFrequentEnglishVerbs.ts
@@ -682,5 +682,7 @@ export const SET = new Set([
   'relax',
   'wrap',
   'unwrap',
-  'rewrap'
+  'rewrap',
+  'delete',
+  'erase'
 ]);


### PR DESCRIPTION
This patch adds the verbse "delete" and "erase" to the list of
accepted verbs in imperative mood.