### PR TITLE
Ignore carriage return

### DIFF
--- a/src/__tests__/inspection.test.ts
+++ b/src/__tests__/inspection.test.ts
@@ -128,12 +128,31 @@ it('reports too long a body line.', () => {
   ]);
 });
 
-it('accepts a body line of exactly 72 characters', () => {
+it('accepts a body line of exactly 72 characters.', () => {
   const message =
     'Do something\n' +
     '\n' +
     'This patch fixes a typo in the readme file where this project was called\n' +
     'dead-csharp instead of doctest-csharp.\n' +
+    '1234567890' +
+    '1234567890' +
+    '1234567890' +
+    '1234567890' +
+    '1234567890' +
+    '1234567890' +
+    '1234567890' +
+    '12';
+
+  const errors = inspection.check(message, new Set<string>());
+  expect(errors).toEqual([]);
+});
+
+it('ignores the carriage return.', () => {
+  const message =
+    'Do something\n' +
+    '\n' +
+    'This patch fixes a typo in the readme file where this project was called\r\n' +
+    'dead-csharp instead of doctest-csharp.\r\n' +
     '1234567890' +
     '1234567890' +
     '1234567890' +

--- a/src/inspection.ts
+++ b/src/inspection.ts
@@ -10,10 +10,18 @@ interface MaybeSubjectBody {
   errors: string[];
 }
 
-function splitSubjectBody(message: string): MaybeSubjectBody {
+function splitLines(message: string): string[] {
+  const lines = message.split('\n');
+  for (let i = 0; i < lines.length; i++) {
+    lines[i] = lines[i].replace(/\r$/, '');
+  }
+
+  return lines;
+}
+
+function splitSubjectBody(lines: string[]): MaybeSubjectBody {
   const result: MaybeSubjectBody = {errors: []};
 
-  const lines = message.split('\n');
   if (lines.length < 3) {
     result.errors.push(
       `Expected at least three lines (subject, empty, body), ` +
@@ -173,7 +181,9 @@ export function check(message: string, additionalVerbs: Set<string>): string[] {
     return errors;
   }
 
-  const maybeSubjectBody = splitSubjectBody(message);
+  const lines = splitLines(message);
+
+  const maybeSubjectBody = splitSubjectBody(lines);
   if (maybeSubjectBody.errors.length > 0) {
     errors.push(...maybeSubjectBody.errors);
   } else {


### PR DESCRIPTION
Windows system add carriage return to the end of lines which triggered
a lot of false positives. This patch ignores the final carriage return
at the end of line.