### PR TITLE
Add text file as input

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -22,3 +22,4 @@ jobs:
       - uses: ./
         with:
           additional-verbs: 'chrusimusi, unit-test'
+          path-to-additional-verbs: src/additional-verbs.txt

--- a/README.md
+++ b/README.md
@@ -93,8 +93,8 @@ However, given the variety of projects in the wild, this whitelist is not
 sufficient to cover all the possible verbs. We therefore introduce the action
 input `additional-verbs` so that you can add your own verbs.
 
-The additional verbs are given as a comma or semicolon separated string in 
-the workflow file. For example:
+The additional verbs are given as a comma, semicolon or new line separated 
+string in the workflow file. For example:
 
 ```yaml
     steps:
@@ -103,6 +103,19 @@ the workflow file. For example:
         with:
           additional-verbs: 'chrusimusi, unit-test'
 ```
+
+If you prefer to have your additional verbs in imperative mood in a separate
+file (*e.g.*, to keep the workflow file succinct), you can supply the path
+as input:
+
+```yaml
+    steps:
+      - name: Check
+        uses: mristin/opinionated-commit-message@v2.0.0-pre1
+        with:
+          path-to-additional-verbs: 'src/additional-verbs.txt'
+```
+
 
 ## Known Issue
 

--- a/src/__tests__/input.test.ts
+++ b/src/__tests__/input.test.ts
@@ -1,0 +1,17 @@
+import * as input from '../input';
+
+it('parses commas, semi-colons and newlines.', () => {
+  const text = 'one, two; three\nfour\n';
+
+  const verbs = input.parseVerbs(text);
+
+  expect(verbs).toEqual(['one', 'two', 'three', 'four']);
+});
+
+it('trims before and after.', () => {
+  const text = 'one, two  ; three\r\nfour\r\n';
+
+  const verbs = input.parseVerbs(text);
+
+  expect(verbs).toEqual(['one', 'two', 'three', 'four']);
+});

--- a/src/additional-verbs.txt
+++ b/src/additional-verbs.txt
@@ -1,0 +1,2 @@
+integration-test
+smoke-test

--- a/src/input.ts
+++ b/src/input.ts
@@ -1,0 +1,17 @@
+import * as core from '@actions/core';
+
+export function parseVerbs(text: string): Array<string> {
+  const lines = text.split('\n');
+
+  const verbs = new Array<string>();
+  for (const line of lines) {
+    const lineVerbs = line
+      .split(/[,;]/)
+      .map(verb => verb.trim().toLowerCase())
+      .filter(verb => verb.length > 0);
+
+    verbs.push(...lineVerbs);
+  }
+
+  return verbs;
+}


### PR DESCRIPTION
While the workflow input `additional-verbs` allows you to whitelist
additional verbs in imperative mood, it can also make the workflow file
barely readable if the list becomes long.

This enhancement allows users to supply an extra file *via*
`path-to-additional-verbs` containing the additional verbs.