### PR TITLE
Add `path-to-additional-verbs` to `action.yml`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,3 +12,7 @@ inputs:
     description: 'Additional verbs in imperative mood to be accepted in checks'
     required: false
     default: ''
+  path-to-additional-verbs:
+    description: 'Path to the file containing the additional verbs in imperative mood to be accepted in checks'
+    required: false
+    default: ''


### PR DESCRIPTION
The input `path-to-additional-verbs` was mistakenly omitted from the
`action.yml` specification. This patch adds it to the specification.