### PR TITLE
Fix GitHub spelling

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,6 @@ from https://chris.beams.io/posts/git-commit:
 * Use the body to explain *what* and *why* (instead of *how*)
 
 If you would like to contribute in code, please fork the repository and create
-the feature branch in your forked repository. See [this Github tuturial](
+the feature branch in your forked repository. See [this GitHub tuturial](
 https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request-from-a-fork
 ) for more guidance. 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ https://img.shields.io/github/v/release/mristin/opinionated-commit-message?style
 https://github.com/mristin/opinionated-commit-message/workflows/build-and-test/badge.svg?branch=master
 )
 
-Opinionated-commit-message is a Github Action which checks commit messages 
+Opinionated-commit-message is a GitHub Action which checks commit messages 
 according to an opinionated style.
 
 The style was inspired by https://chris.beams.io/posts/git-commit/:
@@ -42,9 +42,9 @@ thank the author for the great work!
 
 ## Example Workflow
 
-You can set up a Github workflow to automatically check messages. 
+You can set up a GitHub workflow to automatically check messages. 
 Put the following file in `.github/workflows/check-commit-message.yml` and 
-Github should pick it and set it up.
+GitHub should pick it and set it up.
 
 ```yml
 name: 'Check commit message style'
@@ -71,7 +71,7 @@ jobs:
 
 ## Checked Events
 
-Opinionated-commit-message verifies commit messages on the Github events
+Opinionated-commit-message verifies commit messages on the GitHub events
 [`pull_request`](
 https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request
 ) and [`push`](
@@ -120,7 +120,7 @@ as input:
 
 Splitting URLs on separate lines to satisfy the maximum character lenght 
 breaks the link functionality on most readers
-(*e.g.*, in a terminal or on Github). Therefore we need to tolerate long URLs
+(*e.g.*, in a terminal or on GitHub). Therefore we need to tolerate long URLs
 in the message body. 
 
 Nevertheless, in order to make the text readable the URL should be put either on 
@@ -173,7 +173,7 @@ to be installed.
 ## Known Issue
 
 Commit messages of the pull request are not verified unless you trigger the 
-workflow on the push as well. Github does not include the content of commit 
+workflow on the push as well. GitHub does not include the content of commit 
 messages in the context payload, so checking all the commit messages of 
 the pull request would involve various API call and additional complexity.
 

--- a/local/powershell/OpinionatedCommitMessage.ps1
+++ b/local/powershell/OpinionatedCommitMessage.ps1
@@ -31,7 +31,7 @@ param(
 This script checks commit messages according to an opinionated style.
 
 .DESCRIPTION
-Opinionated-commit-message is a Github Action which checks commit messages according to an opinionated style.
+Opinionated-commit-message is a GitHub Action which checks commit messages according to an opinionated style.
 This script is a rewrite in Powershell meant for local usage.
 
 The style was inspired by https://chris.beams.io/posts/git-commit/:

--- a/local/powershell/OpinionatedCommitMessage.ps1.template
+++ b/local/powershell/OpinionatedCommitMessage.ps1.template
@@ -26,7 +26,7 @@ param(
 This script checks commit messages according to an opinionated style.
 
 .DESCRIPTION
-Opinionated-commit-message is a Github Action which checks commit messages according to an opinionated style.
+Opinionated-commit-message is a GitHub Action which checks commit messages according to an opinionated style.
 This script is a rewrite in Powershell meant for local usage.
 
 The style was inspired by https://chris.beams.io/posts/git-commit/:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mristin/opinionated-commit-message",
   "version": "2.1.2",
-  "description": "Github Action to check commit messages according to an opinionated style",
+  "description": "GitHub Action to check commit messages according to an opinionated style",
   "keywords": [
     "github",
     "actions",

--- a/src/inspection.ts
+++ b/src/inspection.ts
@@ -69,7 +69,7 @@ function checkSubject(subject: string, additionalVerbs: Set<string>): string[] {
   const errors: string[] = [];
 
   // Tolerate the hash code referring, e.g., to a pull request.
-  // These hash codes are usually added automatically by Github and
+  // These hash codes are usually added automatically by GitHub and
   // similar services.
   const subjectWoCode = subject.replace(suffixHashCodeRe, '');
 


### PR DESCRIPTION
Just a minor typo fix: `Github` -> `GitHub`.

Please also fix it here:
![image](https://user-images.githubusercontent.com/743291/90696102-912a5680-e230-11ea-8240-ffcd95458926.png)

Nice project by the way! :+1: