### PR TITLE
Instruct how to remedy reported issues

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,7 +12,7 @@
     "import/no-namespace": "off",
     "no-unused-vars": "off",
     "@typescript-eslint/no-unused-vars": "error",
-    "@typescript-eslint/explicit-member-accessibility": ["error", {"accessibility": "no-public"}],
+    "@typescript-eslint/explicit-member-accessibility": "off",
     "@typescript-eslint/no-require-imports": "error",
     "@typescript-eslint/array-type": "error",
     "@typescript-eslint/await-thenable": "error",

--- a/dist/index.js
+++ b/dist/index.js
@@ -577,11 +577,12 @@ function splitSubjectBody(lines) {
     result.subjectBody = { subject: lines[0], bodyLines: lines.slice(2) };
     return result;
 }
-const capitalizedWordRe = new RegExp('^([A-Z][a-z]*)[^a-zA-Z]');
+const firstWordRe = new RegExp(`^([A-Za-z]{2,})[^A-Za-z]?`);
+const capitalizedWordRe = new RegExp('^[A-Z][a-z]+$');
 const suffixHashCodeRe = new RegExp('\\s?\\(\\s*#[a-zA-Z_0-9]+\\s*\\)$');
-function checkSubject(subject, additionalVerbs) {
+function checkSubject(subject, inputs) {
     // Pre-condition
-    for (const verb of additionalVerbs) {
+    for (const verb of inputs.additionalVerbs) {
         if (verb.length === 0) {
             throw new Error(`Unexpected empty additional verb`);
         }
@@ -591,46 +592,87 @@ function checkSubject(subject, additionalVerbs) {
     }
     const errors = [];
     // Tolerate the hash code referring, e.g., to a pull request.
-    // These hash codes are usually added automatically by Github and
+    // These hash codes are usually added automatically by GitHub and
     // similar services.
     const subjectWoCode = subject.replace(suffixHashCodeRe, '');
     if (subjectWoCode.length > 50) {
         errors.push(`The subject exceeds the limit of 50 characters ` +
-            `(got: ${subject.length}, JSONified: ${JSON.stringify(subjectWoCode)})`);
+            `(got: ${subject.length}, JSON: ${JSON.stringify(subjectWoCode)}).` +
+            'Please shorten the subject to make it more succinct.');
     }
-    const match = capitalizedWordRe.exec(subjectWoCode);
-    if (!match) {
-        errors.push('The subject must start with a capitalized verb (e.g., "Change").');
+    const firstWordMatch = firstWordRe.exec(subjectWoCode);
+    let firstWord = '';
+    if (!firstWordMatch) {
+        // TODO: test this
+        errors.push('The subject must start with a word, ' +
+            `but the subject was: ${JSON.stringify(subject)}. ` +
+            'Please change the first word so that it is written in ' +
+            'two or more letters (without any numbers or special characters).');
     }
     else {
-        if (match.length < 2) {
-            throw Error('Expected at least one group to match the first capitalized word, ' +
+        if (firstWordMatch.length < 2) {
+            throw Error('Expected at least one group to match the first word, ' +
                 'but got none.');
         }
-        const word = match[1];
-        if (!mostFrequentEnglishVerbs.SET.has(word.toLowerCase()) &&
-            !additionalVerbs.has(word.toLowerCase())) {
-            if (additionalVerbs.size === 0) {
-                errors.push('The subject must start in imperative mood with one of the ' +
-                    `most frequent English verbs, but got: ${JSON.stringify(word)}. ` +
-                    'Please see ' +
-                    'https://github.com/mristin/opinionated-commit-message/blob/master/' +
-                    'src/mostFrequentEnglishVerbs.ts ' +
-                    'for a complete list.');
-            }
-            else {
-                errors.push('The subject must start in imperative mood with one of the ' +
-                    `most frequent English verbs, but got: ${JSON.stringify(word)}. ` +
-                    'Please see ' +
-                    'https://github.com/mristin/opinionated-commit-message/blob/master/' +
-                    'src/mostFrequentEnglishVerbs.ts ' +
-                    'for a complete list and ' +
-                    'also revisit your list of additional verbs.');
-            }
+        firstWord = firstWordMatch[1];
+        if (!capitalizedWordRe.exec(firstWord)) {
+            // TODO: test this
+            const capitalized = firstWord[0].toUpperCase() + firstWord.slice(1).toLowerCase();
+            errors.push('The subject must start with a capitalized word, ' +
+                `but the current first word is: ${JSON.stringify(firstWord)}. ` +
+                `Please capitalize to: ${JSON.stringify(capitalized)}.`);
         }
     }
+    if (firstWord.length > 0 &&
+        !mostFrequentEnglishVerbs.SET.has(firstWord.toLowerCase()) &&
+        !inputs.additionalVerbs.has(firstWord.toLowerCase())) {
+        /*
+         (mristin, 2020-09-09): It might be worthwhile to refactor the rendering
+         of the error messages to a separate module and use classes to represent
+         the errors. The complexity is still manageable, so it is not yet the
+         moment to do so since the refactoring would be quite time-consuming.
+    
+         Originally, I did not foresee that error messages need such a large
+         information content.
+         */
+        const parts = [
+            'The subject must start with a verb in imperative mood, ' +
+                `but it started with: ${JSON.stringify(firstWord)}. ` +
+                'Whether the word is in imperative mood is determined by ' +
+                'whitelisting. The general whitelist is available at ' +
+                'https://github.com/mristin/opinionated-commit-message/' +
+                'blob/master/src/mostFrequentEnglishVerbs.ts.'
+        ];
+        // TODO: test both branches
+        if (!inputs.hasAdditionalVerbsInput) {
+            parts.push('You can whitelist additional verbs using ' +
+                '"additional-verbs" input to your GitHub action ' +
+                '(currently no additional verbs were thus specified).');
+        }
+        else {
+            parts.push('You can whitelist additional verbs using ' +
+                '"additional-verbs" input to your GitHub action ' +
+                `(currently one or more additional verbs were thus ` +
+                'specified).');
+        }
+        // TODO: test both branches
+        if (inputs.pathToAdditionalVerbs.length == 0) {
+            parts.push('Moreover, you can also whitelist additional verbs in a file ' +
+                'given as "path-to-additional-verbs" input to your GitHub action ' +
+                '(currently no whitelist file was specified).');
+        }
+        else {
+            parts.push('Moreover, you can also whitelist additional verbs in a file ' +
+                'given as "path-to-additional-verbs" input to your GitHub action ' +
+                `(currently the file is: ${inputs.pathToAdditionalVerbs}).`);
+        }
+        parts.push('Please check the whitelist and either change the first word ' +
+            'of the subject or whitelist the verb.');
+        errors.push(parts.join(' '));
+    }
     if (subjectWoCode.endsWith('.')) {
-        errors.push("The subject must not end with a dot ('.').");
+        errors.push("The subject must not end with a dot ('.'). " +
+            'Please remove the trailing dot(s).');
     }
     return errors;
 }
@@ -654,13 +696,15 @@ function checkBody(subject, bodyLines) {
             errors.push(`The line ${i + 3} of the message (line ${i + 1} of the body) ` +
                 'exceeds the limit of 72 characters. ' +
                 `The line contains ${line.length} characters: ` +
-                `${JSON.stringify(line)}.`);
+                `${JSON.stringify(line)}. ` +
+                'Please reformat the body so that all the lines fit ' +
+                '72 characters.');
         }
     }
-    const bodyFirstWordMatch = capitalizedWordRe.exec(bodyLines[0]);
+    const bodyFirstWordMatch = firstWordRe.exec(bodyLines[0]);
     if (bodyFirstWordMatch) {
         const bodyFirstWord = bodyFirstWordMatch[1];
-        const subjectFirstWordMatch = capitalizedWordRe.exec(subject);
+        const subjectFirstWordMatch = firstWordRe.exec(subject);
         if (subjectFirstWordMatch !== undefined &&
             subjectFirstWordMatch !== null &&
             subjectFirstWordMatch.length > 0) {
@@ -668,8 +712,12 @@ function checkBody(subject, bodyLines) {
             if (subjectFirstWord.toLowerCase() === bodyFirstWord.toLowerCase()) {
                 errors.push('The first word of the subject ' +
                     `(${JSON.stringify(subjectFirstWord)}) ` +
-                    'must not match ' +
-                    'the first word of the body.');
+                    'must not match the first word of the body. ' +
+                    'Please make the body more informative by adding more ' +
+                    'information instead of repeating the subject. ' +
+                    'For example, start by explaining the problem that this change ' +
+                    'is intended to solve or what was previously missing ' +
+                    '(e.g., "Previously, ....").');
             }
         }
     }
@@ -677,7 +725,7 @@ function checkBody(subject, bodyLines) {
 }
 const mergeMessageRe = new RegExp("^Merge branch '[^\\000-\\037\\177 ~^:?*[]+' " +
     'into [^\\000-\\037\\177 ~^:?*[]+$');
-function check(message, additionalVerbs, allowOneLiners) {
+function check(message, inputs) {
     const errors = [];
     if (mergeMessageRe.test(message)) {
         return errors;
@@ -687,8 +735,8 @@ function check(message, additionalVerbs, allowOneLiners) {
         errors.push(`The message is empty.`);
         return errors;
     }
-    else if (lines.length === 1 && allowOneLiners) {
-        errors.push(...checkSubject(lines[0], additionalVerbs));
+    else if (lines.length === 1 && inputs.allowOneLiners) {
+        errors.push(...checkSubject(lines[0], inputs));
     }
     else {
         const maybeSubjectBody = splitSubjectBody(lines);
@@ -700,7 +748,7 @@ function check(message, additionalVerbs, allowOneLiners) {
                 throw Error('Unexpected undefined subjectBody');
             }
             const subjectBody = maybeSubjectBody.subjectBody;
-            errors.push(...checkSubject(subjectBody.subject, additionalVerbs));
+            errors.push(...checkSubject(subjectBody.subject, inputs));
             errors.push(...checkBody(subjectBody.subject, subjectBody.bodyLines));
         }
     }
@@ -713,6 +761,7 @@ function check(message, additionalVerbs, allowOneLiners) {
     return errors;
 }
 exports.check = check;
+// TODO: update messages in powershell!
 
 
 /***/ }),
@@ -4507,64 +4556,36 @@ var __importStar = (this && this.__importStar) || function (mod) {
     __setModuleDefault(result, mod);
     return result;
 };
-var __importDefault = (this && this.__importDefault) || function (mod) {
-    return (mod && mod.__esModule) ? mod : { "default": mod };
-};
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.run = void 0;
-const fs_1 = __importDefault(__webpack_require__(747));
 const core = __importStar(__webpack_require__(470));
 const commitMessages = __importStar(__webpack_require__(281));
 const inspection = __importStar(__webpack_require__(117));
 const represent = __importStar(__webpack_require__(110));
 const input = __importStar(__webpack_require__(553));
 function runWithExceptions() {
+    var _a, _b, _c;
     const messages = commitMessages.retrieve();
-    const additionalVerbs = new Set();
-    // Parse additional-verbs input
-    const additionalVerbsInput = core.getInput('additional-verbs', {
-        required: false
-    });
-    if (additionalVerbsInput) {
-        for (const verb of input.parseVerbs(additionalVerbsInput)) {
-            additionalVerbs.add(verb);
-        }
-    }
-    // Parse additional-verbs-from-path input
-    const pathToAdditionalVerbs = core.getInput('path-to-additional-verbs', {
-        required: false
-    });
-    if (pathToAdditionalVerbs) {
-        if (!fs_1.default.existsSync(pathToAdditionalVerbs)) {
-            const error = 'The file referenced by path-to-additional-verbs could ' +
-                `not be found: ${pathToAdditionalVerbs}`;
-            core.error(error);
-            core.setFailed(error);
-            return;
-        }
-        const text = fs_1.default.readFileSync(pathToAdditionalVerbs).toString('utf-8');
-        for (const verb of input.parseVerbs(text)) {
-            additionalVerbs.add(verb);
-        }
-    }
-    // Parse allow-one-liners input
-    const allowOneLinersText = core.getInput('allow-one-liners', {
-        required: false
-    });
-    const allowOneLiners = !allowOneLinersText
-        ? false
-        : input.parseAllowOneLiners(allowOneLinersText);
-    if (allowOneLiners === null) {
-        const error = 'Unexpected value for allow-one-liners. ' +
-            `Expected either 'true' or 'false', got: ${allowOneLinersText}`;
-        core.error(error);
-        core.setFailed(error);
+    ////
+    // Parse inputs
+    ////
+    const additionalVerbsInput = (_a = core.getInput('additional-verbs', { required: false })) !== null && _a !== void 0 ? _a : '';
+    const pathToAdditionalVerbsInput = (_b = core.getInput('path-to-additional-verbs', { required: false })) !== null && _b !== void 0 ? _b : '';
+    const allowOneLinersInput = (_c = core.getInput('allow-one-liners', { required: false })) !== null && _c !== void 0 ? _c : '';
+    const maybeInputs = input.parseInputs(additionalVerbsInput, pathToAdditionalVerbsInput, allowOneLinersInput);
+    if (maybeInputs.error !== null) {
+        core.error(maybeInputs.error);
+        core.setFailed(maybeInputs.error);
         return;
     }
+    const inputs = maybeInputs.mustInputs();
+    ////
+    // Inspect
+    ////
     // Parts of the error message to be concatenated with '\n'
     const parts = [];
     for (const [messageIndex, message] of messages.entries()) {
-        const errors = inspection.check(message, additionalVerbs, allowOneLiners);
+        const errors = inspection.check(message, inputs);
         if (errors.length > 0) {
             const repr = represent.formatErrors(message, messageIndex, errors);
             parts.push(repr);
@@ -9326,12 +9347,73 @@ function getNextPage (octokit, link, headers) {
 /***/ }),
 
 /***/ 553:
-/***/ (function(__unusedmodule, exports) {
+/***/ (function(__unusedmodule, exports, __webpack_require__) {
 
 "use strict";
 
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.parseAllowOneLiners = exports.parseVerbs = void 0;
+exports.parseAllowOneLiners = exports.parseVerbs = exports.parseInputs = exports.MaybeInputs = exports.Inputs = void 0;
+const fs_1 = __importDefault(__webpack_require__(747));
+class Inputs {
+    constructor(hasAdditionalVerbsInput, pathToAdditionalVerbs, allowOneLiners, additionalVerbs) {
+        this.hasAdditionalVerbsInput = hasAdditionalVerbsInput;
+        this.pathToAdditionalVerbs = pathToAdditionalVerbs;
+        this.allowOneLiners = allowOneLiners;
+        this.additionalVerbs = additionalVerbs;
+    }
+}
+exports.Inputs = Inputs;
+class MaybeInputs {
+    constructor(inputs, error) {
+        if (inputs === null && error === null) {
+            throw Error("Unexpected both 'inputs' and 'error' arguments to be null.");
+        }
+        if (inputs !== null && error !== null) {
+            throw Error("Unexpected both 'inputs' and 'error' arguments to be given.");
+        }
+        this.inputs = inputs;
+        this.error = error;
+    }
+    mustInputs() {
+        if (this.inputs === null) {
+            throw Error("The field 'inputs' is expected to be set, but it is null. " +
+                `The field 'error' is: ${this.error}`);
+        }
+        return this.inputs;
+    }
+}
+exports.MaybeInputs = MaybeInputs;
+function parseInputs(additionalVerbsInput, pathToAdditionalVerbsInput, allowOneLinersInput) {
+    const additionalVerbs = new Set();
+    const hasAdditionalVerbsInput = additionalVerbsInput.length > 0;
+    if (additionalVerbsInput) {
+        for (const verb of parseVerbs(additionalVerbsInput)) {
+            additionalVerbs.add(verb);
+        }
+    }
+    if (pathToAdditionalVerbsInput) {
+        if (!fs_1.default.existsSync(pathToAdditionalVerbsInput)) {
+            return new MaybeInputs(null, 'The file referenced by path-to-additional-verbs could ' +
+                `not be found: ${pathToAdditionalVerbsInput}`);
+        }
+        const text = fs_1.default.readFileSync(pathToAdditionalVerbsInput).toString('utf-8');
+        for (const verb of parseVerbs(text)) {
+            additionalVerbs.add(verb);
+        }
+    }
+    const allowOneLiners = !allowOneLinersInput
+        ? false
+        : parseAllowOneLiners(allowOneLinersInput);
+    if (allowOneLiners === null) {
+        return new MaybeInputs(null, 'Unexpected value for allow-one-liners. ' +
+            `Expected either 'true' or 'false', got: ${allowOneLinersInput}`);
+    }
+    return new MaybeInputs(new Inputs(hasAdditionalVerbsInput, pathToAdditionalVerbsInput, allowOneLiners, additionalVerbs), null);
+}
+exports.parseInputs = parseInputs;
 function parseVerbs(text) {
     const lines = text.split('\n');
     const verbs = [];

--- a/local/powershell/OpinionatedCommitMessage.ps1
+++ b/local/powershell/OpinionatedCommitMessage.ps1
@@ -817,8 +817,46 @@ function ParseAdditionalVerbs($text)
     return $verbs
 }
 
-$capitalizedWordRe = [Regex]::new('^([A-Z][a-z]*)[^a-zA-Z]')
+$allLettersRe = [Regex]::new('^[a-zA-Z][a-zA-Z-]+$')
+$firstWordBeforeSpaceRe = [Regex]::new('^([a-zA-Z][a-zA-Z-]+)\s');
 $suffixHashCodeRe = [Regex]::new('\s?\(\s*#[a-zA-Z_0-9]+\s*\)$')
+
+function ExtractFirstWord([string]$Text)
+{
+    if ($Text.Length -eq 0)
+    {
+        return $null
+    }
+
+    if ($allLettersRe.IsMatch($Text))
+    {
+        return $Text
+    }
+
+    $matches = $firstWordBeforeSpaceRe.Match($Text)
+    if (!$matches.Success)
+    {
+        return $null
+    }
+
+    $firstWord = $matches[0].Groups[1].Value
+    return $firstWord
+}
+
+function Capitalize([string]$word)
+{
+    if ($word.Length -eq 0)
+    {
+        return ""
+    }
+
+    if ($word.Length -eq 1)
+    {
+        return $word.ToUpperInvariant()
+    }
+
+    return $word.Substring(0, 1).ToUpperInvariant() + $word.Substring(1).ToLowerInvariant()
+}
 
 function CheckSubject([string]$subject, [hashtable]$verbs)
 {
@@ -842,31 +880,47 @@ function CheckSubject([string]$subject, [hashtable]$verbs)
     if ($subjectWoCode.Length -gt 50)
     {
         $errors += "The subject exceeds the limit of 50 characters " +    `
-              "(got: $( $subjectWoCode.Length )): $( $subjectWoCode|ConvertTo-Json )"
+              "(got: $( $subjectWoCode.Length )): $( $subjectWoCode|ConvertTo-Json ). " +
+              "Please shorten the subject to make it more succinct."  
     }
 
-    $matches = $capitalizedWordRe.Matches($subjectWoCode)
-    if ($matches.Count -ne 1)
+    $firstWord = ExtractFirstWord -Text $subjectWoCode
+    if ($null -eq $firstWord)
     {
-        $errors += 'The subject must start with a capitalized verb (e.g., "Change").'
-    }
-    else
-    {
-        $match = $matches[0]
-        $word = $match.Groups[1].Value
-        $wordLower = $word.ToLower()
+        $errors += (
+            "Expected the subject to start with a verb in imperative mood " +
+            "consisting of letters and possibly dashes in-between, " +
+            "but the subject was: $($subjectWoCode|ConvertTo-Json). " +
+            "Please re-write the subject so that it starts with " +
+            "a verb in imperative mood."
+        )
+    } else {
+        $capitalized = Capitalize -Word $firstWord
+        if ($capitalized -cne $firstWord)
+        {
+            $errors += (
+                "The subject must start with a capitalized word, " +
+                "but the current first word is: $( $firstWord|ConvertTo-Json ). " +
+                "Please capitalize to: $( $capitalized|ConvertTo-Json )."
+            )
+        }
 
-        if (!$verbs.Contains($wordLower) -or ($false -eq $verbs[$wordLower]))
+        $firstWordLower = $firstWord.ToLower()
+
+        if (!$verbs.Contains($firstWordLower) -or ($false -eq $verbs[$firstWordLower]))
         {
             $errors += "The subject must start with a verb in imperative mood (according to a whitelist), " +   `
-                  "but got: $($word|ConvertTo-Json); if this is a false positive, consider adding the verb " + `
+                  "but got: $($firstWord|ConvertTo-Json); if this is a false positive, consider adding the verb " + `
                   "to -additionalVerbs or to the file referenced by -pathToAdditionalVerbs."
         }
     }
 
     if ( $subjectWoCode.EndsWith("."))
     {
-        $errors += "The subject must not end with a dot ('.')."
+        $errors += (
+            "The subject must not end with a dot ('.'). " +
+            "Please remove the trailing dot(s)."
+        )
     }
 
     return $errors
@@ -902,26 +956,30 @@ function CheckBody([string]$subject, [string[]] $bodyLines)
 
         if($line.Length -gt 72)
         {
-            $errors += "The line $($i + 3) of the message (line $($i + 1) of the body) " + `
-                "exceeds the limit of 72 characters. The line contains $($line.Length) characters: " + `
-                "$($line|ConvertTo-Json)."
+            $errors += (
+                "The line $($i + 3) of the message (line $($i + 1) of the body) " +
+                "exceeds the limit of 72 characters. The line contains $($line.Length) characters: " +
+                "$($line|ConvertTo-Json). " +
+                "Please reformat the body so that all the lines fit 72 characters."
+            )
         }
     }
 
-    $bodyFirstWordMatches = $capitalizedWordRe.Matches($bodyLines[0])
-    if($bodyFirstWordMatches.Count -eq 1)
+    $bodyFirstWord = ExtractFirstWord -Text $bodyLines[0]
+    if($null -ne $bodyFirstWord)
     {
-        $bodyFirstWord = $bodyFirstWordMatches[0].Groups[1].Value
-
-        $subjectFirstWordMatches = $capitalizedWordRe.Matches($subject)
-        if($subjectFirstWordMatches.Count -eq 1)
+        $subjectFirstWord = ExtractFirstWord -Text $subject
+        if($null -ne $subjectFirstWord)
         {
-            $subjectFirstWord = $subjectFirstWordMatches[0].Groups[1].Value
-
             if($subjectFirstWord.ToLower() -eq $bodyFirstWord.ToLower())
             {
-                $errors += "The first word of the subject ($($subjectFirstWord|ConvertTo-Json)) must not match " + `
-                    "the first word of the body."
+                $errors += (
+                    "The first word of the subject ($($subjectFirstWord|ConvertTo-Json)) must not match " +
+                    "the first word of the body. " +
+                    "Please make the body more informative by adding more information instead of repeating " +
+                    "the subject. For example, start by explaining the problem that this change is " +
+                    'intendended to solve or what was previously missing (e.g., "Previously, ....").'
+                )
             }
         }
     }

--- a/local/powershell/OpinionatedCommitMessage.ps1.template
+++ b/local/powershell/OpinionatedCommitMessage.ps1.template
@@ -77,8 +77,46 @@ function ParseAdditionalVerbs($text)
     return $verbs
 }
 
-$capitalizedWordRe = [Regex]::new('^([A-Z][a-z]*)[^a-zA-Z]')
+$allLettersRe = [Regex]::new('^[a-zA-Z][a-zA-Z-]+$')
+$firstWordBeforeSpaceRe = [Regex]::new('^([a-zA-Z][a-zA-Z-]+)\s');
 $suffixHashCodeRe = [Regex]::new('\s?\(\s*#[a-zA-Z_0-9]+\s*\)$')
+
+function ExtractFirstWord([string]$Text)
+{
+    if ($Text.Length -eq 0)
+    {
+        return $null
+    }
+
+    if ($allLettersRe.IsMatch($Text))
+    {
+        return $Text
+    }
+
+    $matches = $firstWordBeforeSpaceRe.Match($Text)
+    if (!$matches.Success)
+    {
+        return $null
+    }
+
+    $firstWord = $matches[0].Groups[1].Value
+    return $firstWord
+}
+
+function Capitalize([string]$word)
+{
+    if ($word.Length -eq 0)
+    {
+        return ""
+    }
+
+    if ($word.Length -eq 1)
+    {
+        return $word.ToUpperInvariant()
+    }
+
+    return $word.Substring(0, 1).ToUpperInvariant() + $word.Substring(1).ToLowerInvariant()
+}
 
 function CheckSubject([string]$subject, [hashtable]$verbs)
 {
@@ -102,31 +140,47 @@ function CheckSubject([string]$subject, [hashtable]$verbs)
     if ($subjectWoCode.Length -gt 50)
     {
         $errors += "The subject exceeds the limit of 50 characters " +    `
-              "(got: $( $subjectWoCode.Length )): $( $subjectWoCode|ConvertTo-Json )"
+              "(got: $( $subjectWoCode.Length )): $( $subjectWoCode|ConvertTo-Json ). " +
+              "Please shorten the subject to make it more succinct."  
     }
 
-    $matches = $capitalizedWordRe.Matches($subjectWoCode)
-    if ($matches.Count -ne 1)
+    $firstWord = ExtractFirstWord -Text $subjectWoCode
+    if ($null -eq $firstWord)
     {
-        $errors += 'The subject must start with a capitalized verb (e.g., "Change").'
-    }
-    else
-    {
-        $match = $matches[0]
-        $word = $match.Groups[1].Value
-        $wordLower = $word.ToLower()
+        $errors += (
+            "Expected the subject to start with a verb in imperative mood " +
+            "consisting of letters and possibly dashes in-between, " +
+            "but the subject was: $($subjectWoCode|ConvertTo-Json). " +
+            "Please re-write the subject so that it starts with " +
+            "a verb in imperative mood."
+        )
+    } else {
+        $capitalized = Capitalize -Word $firstWord
+        if ($capitalized -cne $firstWord)
+        {
+            $errors += (
+                "The subject must start with a capitalized word, " +
+                "but the current first word is: $( $firstWord|ConvertTo-Json ). " +
+                "Please capitalize to: $( $capitalized|ConvertTo-Json )."
+            )
+        }
 
-        if (!$verbs.Contains($wordLower) -or ($false -eq $verbs[$wordLower]))
+        $firstWordLower = $firstWord.ToLower()
+
+        if (!$verbs.Contains($firstWordLower) -or ($false -eq $verbs[$firstWordLower]))
         {
             $errors += "The subject must start with a verb in imperative mood (according to a whitelist), " +   `
-                  "but got: $($word|ConvertTo-Json); if this is a false positive, consider adding the verb " + `
+                  "but got: $($firstWord|ConvertTo-Json); if this is a false positive, consider adding the verb " + `
                   "to -additionalVerbs or to the file referenced by -pathToAdditionalVerbs."
         }
     }
 
     if ( $subjectWoCode.EndsWith("."))
     {
-        $errors += "The subject must not end with a dot ('.')."
+        $errors += (
+            "The subject must not end with a dot ('.'). " +
+            "Please remove the trailing dot(s)."
+        )
     }
 
     return $errors
@@ -162,26 +216,30 @@ function CheckBody([string]$subject, [string[]] $bodyLines)
 
         if($line.Length -gt 72)
         {
-            $errors += "The line $($i + 3) of the message (line $($i + 1) of the body) " + `
-                "exceeds the limit of 72 characters. The line contains $($line.Length) characters: " + `
-                "$($line|ConvertTo-Json)."
+            $errors += (
+                "The line $($i + 3) of the message (line $($i + 1) of the body) " +
+                "exceeds the limit of 72 characters. The line contains $($line.Length) characters: " +
+                "$($line|ConvertTo-Json). " +
+                "Please reformat the body so that all the lines fit 72 characters."
+            )
         }
     }
 
-    $bodyFirstWordMatches = $capitalizedWordRe.Matches($bodyLines[0])
-    if($bodyFirstWordMatches.Count -eq 1)
+    $bodyFirstWord = ExtractFirstWord -Text $bodyLines[0]
+    if($null -ne $bodyFirstWord)
     {
-        $bodyFirstWord = $bodyFirstWordMatches[0].Groups[1].Value
-
-        $subjectFirstWordMatches = $capitalizedWordRe.Matches($subject)
-        if($subjectFirstWordMatches.Count -eq 1)
+        $subjectFirstWord = ExtractFirstWord -Text $subject
+        if($null -ne $subjectFirstWord)
         {
-            $subjectFirstWord = $subjectFirstWordMatches[0].Groups[1].Value
-
             if($subjectFirstWord.ToLower() -eq $bodyFirstWord.ToLower())
             {
-                $errors += "The first word of the subject ($($subjectFirstWord|ConvertTo-Json)) must not match " + `
-                    "the first word of the body."
+                $errors += (
+                    "The first word of the subject ($($subjectFirstWord|ConvertTo-Json)) must not match " +
+                    "the first word of the body. " +
+                    "Please make the body more informative by adding more information instead of repeating " +
+                    "the subject. For example, start by explaining the problem that this change is " +
+                    'intendended to solve or what was previously missing (e.g., "Previously, ....").'
+                )
             }
         }
     }

--- a/src/__tests__/input.test.ts
+++ b/src/__tests__/input.test.ts
@@ -1,4 +1,5 @@
 import * as input from '../input';
+import fs from 'fs';
 
 it('parses commas, semi-colons and newlines.', () => {
   const text = 'one, two; three\nfour\n';
@@ -14,4 +15,34 @@ it('trims before and after.', () => {
   const verbs = input.parseVerbs(text);
 
   expect(verbs).toEqual(['one', 'two', 'three', 'four']);
+});
+
+it('parses the inputs.', () => {
+  const pathToVerbs = '/some/path/to/additional/verbs';
+
+  (fs as any).existsSync = (path: string) => path === pathToVerbs;
+
+  (fs as any).readFileSync = (path: string) => {
+    if (path === pathToVerbs) {
+      return 'rewrap\ntable';
+    }
+
+    throw new Error(`Unexpected readFileSync in the unit test from: ${path}`);
+  };
+
+  const maybeInputs = input.parseInputs(
+    'integrate\nanalyze',
+    pathToVerbs,
+    'true'
+  );
+
+  expect(maybeInputs.error).toBeNull();
+
+  const inputs = maybeInputs.mustInputs();
+  expect(inputs.hasAdditionalVerbsInput).toBeTruthy();
+  expect(inputs.pathToAdditionalVerbs).toEqual(pathToVerbs);
+  expect(inputs.additionalVerbs).toEqual(
+    new Set<string>(['rewrap', 'table', 'integrate', 'analyze'])
+  );
+  expect(inputs.allowOneLiners).toBeTruthy();
 });

--- a/src/__tests__/main.test.ts
+++ b/src/__tests__/main.test.ts
@@ -87,7 +87,7 @@ it('formats properly no error message.', () => {
 
 it('formats properly errors on a single message.', () => {
   (commitMessages.retrieve as any).mockImplementation(() => [
-    'SomeClass to OtherClass\n\nSomeClass with OtherClass'
+    'change SomeClass to OtherClass\n\nSomeClass with OtherClass'
   ]);
 
   const mockSetFailed = jest.fn();
@@ -97,9 +97,11 @@ it('formats properly errors on a single message.', () => {
   expect(mockSetFailed.mock.calls).toEqual([
     [
       'The message 1 is invalid:\n' +
-        '* The subject must start with a capitalized verb (e.g., "Change").\n' +
+        '* The subject must start with a capitalized word, but ' +
+        'the current first word is: "change". ' +
+        'Please capitalize to: "Change".\n' +
         'The original message was:\n' +
-        'SomeClass to OtherClass\n' +
+        'change SomeClass to OtherClass\n' +
         '\n' +
         'SomeClass with OtherClass\n'
     ]
@@ -108,7 +110,7 @@ it('formats properly errors on a single message.', () => {
 
 it('formats properly errors on two messages.', () => {
   (commitMessages.retrieve as any).mockImplementation(() => [
-    `SomeClass to OtherClass\n\n${'A'.repeat(73)}`,
+    `change SomeClass to OtherClass\n\nDo something`,
     'Change other subject\n\nChange body'
   ]);
 
@@ -119,23 +121,21 @@ it('formats properly errors on two messages.', () => {
 
   expect(mockSetFailed.mock.calls).toEqual([
     [
-      `${'The message 1 is invalid:\n' +
-        '* The subject must start with a capitalized verb (e.g., "Change").\n' +
-        '* The line 3 of the message (line 1 of the body) exceeds ' +
-        'the limit of 72 characters. The line contains 73 characters: "'}${'A'.repeat(
-        73
-      )}".\n` +
-        `The original message was:\n` +
-        `SomeClass to OtherClass\n` +
-        `\n${'A'.repeat(73)}\n` +
-        `\n` +
-        `The message 2 is invalid:\n` +
-        `* The first word of the subject ("Change") must not match ` +
-        `the first word of the body.\n` +
-        `The original message was:\n` +
-        `Change other subject\n` +
-        `\n` +
-        `Change body\n`
+      'The message 1 is invalid:\n' +
+        '* The subject must start with a capitalized word, ' +
+        'but the current first word is: "change". ' +
+        'Please capitalize to: "Change".\n' +
+        'The original message was:\n' +
+        'change SomeClass to OtherClass\n\nDo something\n\n' +
+        'The message 2 is invalid:\n' +
+        '* The first word of the subject ("Change") must not match ' +
+        'the first word of the body. Please make the body more informative ' +
+        'by adding more information instead of repeating the subject. ' +
+        'For example, start by explaining the problem that this change ' +
+        'is intended to solve or what was previously missing ' +
+        '(e.g., "Previously, ....").\n' +
+        'The original message was:\n' +
+        'Change other subject\n\nChange body\n'
     ]
   ]);
 });

--- a/src/input.ts
+++ b/src/input.ts
@@ -1,3 +1,112 @@
+import fs from 'fs';
+
+export class Inputs {
+  public hasAdditionalVerbsInput: boolean;
+  public pathToAdditionalVerbs: string;
+  public allowOneLiners: boolean;
+
+  // This is a complete appendix to the whiltelist parsed both from
+  // the GitHub action input "additional-verbs" and from the file
+  // specified by the input "path-to-additional-verbs".
+  additionalVerbs: Set<string>;
+
+  constructor(
+    hasAdditionalVerbsInput: boolean,
+    pathToAdditionalVerbs: string,
+    allowOneLiners: boolean,
+    additionalVerbs: Set<string>
+  ) {
+    this.hasAdditionalVerbsInput = hasAdditionalVerbsInput;
+    this.pathToAdditionalVerbs = pathToAdditionalVerbs;
+    this.allowOneLiners = allowOneLiners;
+    this.additionalVerbs = additionalVerbs;
+  }
+}
+
+export class MaybeInputs {
+  public inputs: Inputs | null;
+  public error: string | null;
+
+  constructor(inputs: Inputs | null, error: string | null) {
+    if (inputs === null && error === null) {
+      throw Error("Unexpected both 'inputs' and 'error' arguments to be null.");
+    }
+
+    if (inputs !== null && error !== null) {
+      throw Error(
+        "Unexpected both 'inputs' and 'error' arguments to be given."
+      );
+    }
+
+    this.inputs = inputs;
+    this.error = error;
+  }
+
+  public mustInputs(): Inputs {
+    if (this.inputs === null) {
+      throw Error(
+        "The field 'inputs' is expected to be set, but it is null. " +
+          `The field 'error' is: ${this.error}`
+      );
+    }
+    return this.inputs;
+  }
+}
+
+export function parseInputs(
+  additionalVerbsInput: string,
+  pathToAdditionalVerbsInput: string,
+  allowOneLinersInput: string
+): MaybeInputs {
+  const additionalVerbs = new Set<string>();
+
+  const hasAdditionalVerbsInput = additionalVerbsInput.length > 0;
+
+  if (additionalVerbsInput) {
+    for (const verb of parseVerbs(additionalVerbsInput)) {
+      additionalVerbs.add(verb);
+    }
+  }
+
+  if (pathToAdditionalVerbsInput) {
+    if (!fs.existsSync(pathToAdditionalVerbsInput)) {
+      return new MaybeInputs(
+        null,
+        'The file referenced by path-to-additional-verbs could ' +
+          `not be found: ${pathToAdditionalVerbsInput}`
+      );
+    }
+
+    const text = fs.readFileSync(pathToAdditionalVerbsInput).toString('utf-8');
+
+    for (const verb of parseVerbs(text)) {
+      additionalVerbs.add(verb);
+    }
+  }
+
+  const allowOneLiners: boolean | null = !allowOneLinersInput
+    ? false
+    : parseAllowOneLiners(allowOneLinersInput);
+
+  if (allowOneLiners === null) {
+    return new MaybeInputs(
+      null,
+      'Unexpected value for allow-one-liners. ' +
+        `Expected either 'true' or 'false', got: ${allowOneLinersInput}`
+    );
+  }
+
+  return new MaybeInputs(
+    new Inputs(
+      hasAdditionalVerbsInput,
+      pathToAdditionalVerbsInput,
+      allowOneLiners,
+      additionalVerbs
+    ),
+    null
+  );
+}
+
 export function parseVerbs(text: string): string[] {
   const lines = text.split('\n');
 


### PR DESCRIPTION
Oftentimes, the wider team is not aware how the GitHub action has
been set up and merely sees the messages in their CI reports. These
users are ultimately lost and need further guidance on how to fix the
issues in their commit messages. In particular, sparse error messages
with no hints about the remedy are almost useless leaving the users 
utterly frustrated.

This change introduces verbose error messages which include the
hints what can be done about the commit message. While the messages are
now quite long and seem cluttered, they are hopefully much more useful 
to the inexperienced users.