### PR TITLE
Instruct how to remedy the issues

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,7 +12,7 @@
     "import/no-namespace": "off",
     "no-unused-vars": "off",
     "@typescript-eslint/no-unused-vars": "error",
-    "@typescript-eslint/explicit-member-accessibility": ["error", {"accessibility": "no-public"}],
+    "@typescript-eslint/explicit-member-accessibility": "off",
     "@typescript-eslint/no-require-imports": "error",
     "@typescript-eslint/array-type": "error",
     "@typescript-eslint/await-thenable": "error",

--- a/local/powershell/OpinionatedCommitMessage.ps1
+++ b/local/powershell/OpinionatedCommitMessage.ps1
@@ -410,6 +410,7 @@ $frequentVerbs = @(
 'inline',
 'insist',
 'install',
+'instruct',
 'integrate',
 'intend',
 'intercept',
@@ -817,8 +818,46 @@ function ParseAdditionalVerbs($text)
     return $verbs
 }
 
-$capitalizedWordRe = [Regex]::new('^([A-Z][a-z]*)[^a-zA-Z]')
+$allLettersRe = [Regex]::new('^[a-zA-Z][a-zA-Z-]+$')
+$firstWordBeforeSpaceRe = [Regex]::new('^([a-zA-Z][a-zA-Z-]+)\s');
 $suffixHashCodeRe = [Regex]::new('\s?\(\s*#[a-zA-Z_0-9]+\s*\)$')
+
+function ExtractFirstWord([string]$Text)
+{
+    if ($Text.Length -eq 0)
+    {
+        return $null
+    }
+
+    if ($allLettersRe.IsMatch($Text))
+    {
+        return $Text
+    }
+
+    $matches = $firstWordBeforeSpaceRe.Match($Text)
+    if (!$matches.Success)
+    {
+        return $null
+    }
+
+    $firstWord = $matches[0].Groups[1].Value
+    return $firstWord
+}
+
+function Capitalize([string]$word)
+{
+    if ($word.Length -eq 0)
+    {
+        return ""
+    }
+
+    if ($word.Length -eq 1)
+    {
+        return $word.ToUpperInvariant()
+    }
+
+    return $word.Substring(0, 1).ToUpperInvariant() + $word.Substring(1).ToLowerInvariant()
+}
 
 function CheckSubject([string]$subject, [hashtable]$verbs)
 {
@@ -842,31 +881,47 @@ function CheckSubject([string]$subject, [hashtable]$verbs)
     if ($subjectWoCode.Length -gt 50)
     {
         $errors += "The subject exceeds the limit of 50 characters " +    `
-              "(got: $( $subjectWoCode.Length )): $( $subjectWoCode|ConvertTo-Json )"
+              "(got: $( $subjectWoCode.Length )): $( $subjectWoCode|ConvertTo-Json ). " +
+              "Please shorten the subject to make it more succinct."  
     }
 
-    $matches = $capitalizedWordRe.Matches($subjectWoCode)
-    if ($matches.Count -ne 1)
+    $firstWord = ExtractFirstWord -Text $subjectWoCode
+    if ($null -eq $firstWord)
     {
-        $errors += 'The subject must start with a capitalized verb (e.g., "Change").'
-    }
-    else
-    {
-        $match = $matches[0]
-        $word = $match.Groups[1].Value
-        $wordLower = $word.ToLower()
+        $errors += (
+            "Expected the subject to start with a verb in imperative mood " +
+            "consisting of letters and possibly dashes in-between, " +
+            "but the subject was: $($subjectWoCode|ConvertTo-Json). " +
+            "Please re-write the subject so that it starts with " +
+            "a verb in imperative mood."
+        )
+    } else {
+        $capitalized = Capitalize -Word $firstWord
+        if ($capitalized -cne $firstWord)
+        {
+            $errors += (
+                "The subject must start with a capitalized word, " +
+                "but the current first word is: $( $firstWord|ConvertTo-Json ). " +
+                "Please capitalize to: $( $capitalized|ConvertTo-Json )."
+            )
+        }
 
-        if (!$verbs.Contains($wordLower) -or ($false -eq $verbs[$wordLower]))
+        $firstWordLower = $firstWord.ToLower()
+
+        if (!$verbs.Contains($firstWordLower) -or ($false -eq $verbs[$firstWordLower]))
         {
             $errors += "The subject must start with a verb in imperative mood (according to a whitelist), " +   `
-                  "but got: $($word|ConvertTo-Json); if this is a false positive, consider adding the verb " + `
+                  "but got: $($firstWord|ConvertTo-Json); if this is a false positive, consider adding the verb " + `
                   "to -additionalVerbs or to the file referenced by -pathToAdditionalVerbs."
         }
     }
 
     if ( $subjectWoCode.EndsWith("."))
     {
-        $errors += "The subject must not end with a dot ('.')."
+        $errors += (
+            "The subject must not end with a dot ('.'). " +
+            "Please remove the trailing dot(s)."
+        )
     }
 
     return $errors
@@ -902,26 +957,30 @@ function CheckBody([string]$subject, [string[]] $bodyLines)
 
         if($line.Length -gt 72)
         {
-            $errors += "The line $($i + 3) of the message (line $($i + 1) of the body) " + `
-                "exceeds the limit of 72 characters. The line contains $($line.Length) characters: " + `
-                "$($line|ConvertTo-Json)."
+            $errors += (
+                "The line $($i + 3) of the message (line $($i + 1) of the body) " +
+                "exceeds the limit of 72 characters. The line contains $($line.Length) characters: " +
+                "$($line|ConvertTo-Json). " +
+                "Please reformat the body so that all the lines fit 72 characters."
+            )
         }
     }
 
-    $bodyFirstWordMatches = $capitalizedWordRe.Matches($bodyLines[0])
-    if($bodyFirstWordMatches.Count -eq 1)
+    $bodyFirstWord = ExtractFirstWord -Text $bodyLines[0]
+    if($null -ne $bodyFirstWord)
     {
-        $bodyFirstWord = $bodyFirstWordMatches[0].Groups[1].Value
-
-        $subjectFirstWordMatches = $capitalizedWordRe.Matches($subject)
-        if($subjectFirstWordMatches.Count -eq 1)
+        $subjectFirstWord = ExtractFirstWord -Text $subject
+        if($null -ne $subjectFirstWord)
         {
-            $subjectFirstWord = $subjectFirstWordMatches[0].Groups[1].Value
-
             if($subjectFirstWord.ToLower() -eq $bodyFirstWord.ToLower())
             {
-                $errors += "The first word of the subject ($($subjectFirstWord|ConvertTo-Json)) must not match " + `
-                    "the first word of the body."
+                $errors += (
+                    "The first word of the subject ($($subjectFirstWord|ConvertTo-Json)) must not match " +
+                    "the first word of the body. " +
+                    "Please make the body more informative by adding more information instead of repeating " +
+                    "the subject. For example, start by explaining the problem that this change is " +
+                    'intendended to solve or what was previously missing (e.g., "Previously, ....").'
+                )
             }
         }
     }

--- a/local/powershell/OpinionatedCommitMessage.ps1.template
+++ b/local/powershell/OpinionatedCommitMessage.ps1.template
@@ -77,8 +77,46 @@ function ParseAdditionalVerbs($text)
     return $verbs
 }
 
-$capitalizedWordRe = [Regex]::new('^([A-Z][a-z]*)[^a-zA-Z]')
+$allLettersRe = [Regex]::new('^[a-zA-Z][a-zA-Z-]+$')
+$firstWordBeforeSpaceRe = [Regex]::new('^([a-zA-Z][a-zA-Z-]+)\s');
 $suffixHashCodeRe = [Regex]::new('\s?\(\s*#[a-zA-Z_0-9]+\s*\)$')
+
+function ExtractFirstWord([string]$Text)
+{
+    if ($Text.Length -eq 0)
+    {
+        return $null
+    }
+
+    if ($allLettersRe.IsMatch($Text))
+    {
+        return $Text
+    }
+
+    $matches = $firstWordBeforeSpaceRe.Match($Text)
+    if (!$matches.Success)
+    {
+        return $null
+    }
+
+    $firstWord = $matches[0].Groups[1].Value
+    return $firstWord
+}
+
+function Capitalize([string]$word)
+{
+    if ($word.Length -eq 0)
+    {
+        return ""
+    }
+
+    if ($word.Length -eq 1)
+    {
+        return $word.ToUpperInvariant()
+    }
+
+    return $word.Substring(0, 1).ToUpperInvariant() + $word.Substring(1).ToLowerInvariant()
+}
 
 function CheckSubject([string]$subject, [hashtable]$verbs)
 {
@@ -102,31 +140,47 @@ function CheckSubject([string]$subject, [hashtable]$verbs)
     if ($subjectWoCode.Length -gt 50)
     {
         $errors += "The subject exceeds the limit of 50 characters " +    `
-              "(got: $( $subjectWoCode.Length )): $( $subjectWoCode|ConvertTo-Json )"
+              "(got: $( $subjectWoCode.Length )): $( $subjectWoCode|ConvertTo-Json ). " +
+              "Please shorten the subject to make it more succinct."  
     }
 
-    $matches = $capitalizedWordRe.Matches($subjectWoCode)
-    if ($matches.Count -ne 1)
+    $firstWord = ExtractFirstWord -Text $subjectWoCode
+    if ($null -eq $firstWord)
     {
-        $errors += 'The subject must start with a capitalized verb (e.g., "Change").'
-    }
-    else
-    {
-        $match = $matches[0]
-        $word = $match.Groups[1].Value
-        $wordLower = $word.ToLower()
+        $errors += (
+            "Expected the subject to start with a verb in imperative mood " +
+            "consisting of letters and possibly dashes in-between, " +
+            "but the subject was: $($subjectWoCode|ConvertTo-Json). " +
+            "Please re-write the subject so that it starts with " +
+            "a verb in imperative mood."
+        )
+    } else {
+        $capitalized = Capitalize -Word $firstWord
+        if ($capitalized -cne $firstWord)
+        {
+            $errors += (
+                "The subject must start with a capitalized word, " +
+                "but the current first word is: $( $firstWord|ConvertTo-Json ). " +
+                "Please capitalize to: $( $capitalized|ConvertTo-Json )."
+            )
+        }
 
-        if (!$verbs.Contains($wordLower) -or ($false -eq $verbs[$wordLower]))
+        $firstWordLower = $firstWord.ToLower()
+
+        if (!$verbs.Contains($firstWordLower) -or ($false -eq $verbs[$firstWordLower]))
         {
             $errors += "The subject must start with a verb in imperative mood (according to a whitelist), " +   `
-                  "but got: $($word|ConvertTo-Json); if this is a false positive, consider adding the verb " + `
+                  "but got: $($firstWord|ConvertTo-Json); if this is a false positive, consider adding the verb " + `
                   "to -additionalVerbs or to the file referenced by -pathToAdditionalVerbs."
         }
     }
 
     if ( $subjectWoCode.EndsWith("."))
     {
-        $errors += "The subject must not end with a dot ('.')."
+        $errors += (
+            "The subject must not end with a dot ('.'). " +
+            "Please remove the trailing dot(s)."
+        )
     }
 
     return $errors
@@ -162,26 +216,30 @@ function CheckBody([string]$subject, [string[]] $bodyLines)
 
         if($line.Length -gt 72)
         {
-            $errors += "The line $($i + 3) of the message (line $($i + 1) of the body) " + `
-                "exceeds the limit of 72 characters. The line contains $($line.Length) characters: " + `
-                "$($line|ConvertTo-Json)."
+            $errors += (
+                "The line $($i + 3) of the message (line $($i + 1) of the body) " +
+                "exceeds the limit of 72 characters. The line contains $($line.Length) characters: " +
+                "$($line|ConvertTo-Json). " +
+                "Please reformat the body so that all the lines fit 72 characters."
+            )
         }
     }
 
-    $bodyFirstWordMatches = $capitalizedWordRe.Matches($bodyLines[0])
-    if($bodyFirstWordMatches.Count -eq 1)
+    $bodyFirstWord = ExtractFirstWord -Text $bodyLines[0]
+    if($null -ne $bodyFirstWord)
     {
-        $bodyFirstWord = $bodyFirstWordMatches[0].Groups[1].Value
-
-        $subjectFirstWordMatches = $capitalizedWordRe.Matches($subject)
-        if($subjectFirstWordMatches.Count -eq 1)
+        $subjectFirstWord = ExtractFirstWord -Text $subject
+        if($null -ne $subjectFirstWord)
         {
-            $subjectFirstWord = $subjectFirstWordMatches[0].Groups[1].Value
-
             if($subjectFirstWord.ToLower() -eq $bodyFirstWord.ToLower())
             {
-                $errors += "The first word of the subject ($($subjectFirstWord|ConvertTo-Json)) must not match " + `
-                    "the first word of the body."
+                $errors += (
+                    "The first word of the subject ($($subjectFirstWord|ConvertTo-Json)) must not match " +
+                    "the first word of the body. " +
+                    "Please make the body more informative by adding more information instead of repeating " +
+                    "the subject. For example, start by explaining the problem that this change is " +
+                    'intendended to solve or what was previously missing (e.g., "Previously, ....").'
+                )
             }
         }
     }

--- a/src/__tests__/input.test.ts
+++ b/src/__tests__/input.test.ts
@@ -1,4 +1,5 @@
 import * as input from '../input';
+import fs from 'fs';
 
 it('parses commas, semi-colons and newlines.', () => {
   const text = 'one, two; three\nfour\n';
@@ -14,4 +15,34 @@ it('trims before and after.', () => {
   const verbs = input.parseVerbs(text);
 
   expect(verbs).toEqual(['one', 'two', 'three', 'four']);
+});
+
+it('parses the inputs.', () => {
+  const pathToVerbs = '/some/path/to/additional/verbs';
+
+  (fs as any).existsSync = (path: string) => path === pathToVerbs;
+
+  (fs as any).readFileSync = (path: string) => {
+    if (path === pathToVerbs) {
+      return 'rewrap\ntable';
+    }
+
+    throw new Error(`Unexpected readFileSync in the unit test from: ${path}`);
+  };
+
+  const maybeInputs = input.parseInputs(
+    'integrate\nanalyze',
+    pathToVerbs,
+    'true'
+  );
+
+  expect(maybeInputs.error).toBeNull();
+
+  const inputs = maybeInputs.mustInputs();
+  expect(inputs.hasAdditionalVerbsInput).toBeTruthy();
+  expect(inputs.pathToAdditionalVerbs).toEqual(pathToVerbs);
+  expect(inputs.additionalVerbs).toEqual(
+    new Set<string>(['rewrap', 'table', 'integrate', 'analyze'])
+  );
+  expect(inputs.allowOneLiners).toBeTruthy();
 });

--- a/src/__tests__/main.test.ts
+++ b/src/__tests__/main.test.ts
@@ -87,7 +87,7 @@ it('formats properly no error message.', () => {
 
 it('formats properly errors on a single message.', () => {
   (commitMessages.retrieve as any).mockImplementation(() => [
-    'SomeClass to OtherClass\n\nSomeClass with OtherClass'
+    'change SomeClass to OtherClass\n\nSomeClass with OtherClass'
   ]);
 
   const mockSetFailed = jest.fn();
@@ -97,9 +97,11 @@ it('formats properly errors on a single message.', () => {
   expect(mockSetFailed.mock.calls).toEqual([
     [
       'The message 1 is invalid:\n' +
-        '* The subject must start with a capitalized verb (e.g., "Change").\n' +
+        '* The subject must start with a capitalized word, but ' +
+        'the current first word is: "change". ' +
+        'Please capitalize to: "Change".\n' +
         'The original message was:\n' +
-        'SomeClass to OtherClass\n' +
+        'change SomeClass to OtherClass\n' +
         '\n' +
         'SomeClass with OtherClass\n'
     ]
@@ -108,7 +110,7 @@ it('formats properly errors on a single message.', () => {
 
 it('formats properly errors on two messages.', () => {
   (commitMessages.retrieve as any).mockImplementation(() => [
-    `SomeClass to OtherClass\n\n${'A'.repeat(73)}`,
+    `change SomeClass to OtherClass\n\nDo something`,
     'Change other subject\n\nChange body'
   ]);
 
@@ -119,23 +121,21 @@ it('formats properly errors on two messages.', () => {
 
   expect(mockSetFailed.mock.calls).toEqual([
     [
-      `${'The message 1 is invalid:\n' +
-        '* The subject must start with a capitalized verb (e.g., "Change").\n' +
-        '* The line 3 of the message (line 1 of the body) exceeds ' +
-        'the limit of 72 characters. The line contains 73 characters: "'}${'A'.repeat(
-        73
-      )}".\n` +
-        `The original message was:\n` +
-        `SomeClass to OtherClass\n` +
-        `\n${'A'.repeat(73)}\n` +
-        `\n` +
-        `The message 2 is invalid:\n` +
-        `* The first word of the subject ("Change") must not match ` +
-        `the first word of the body.\n` +
-        `The original message was:\n` +
-        `Change other subject\n` +
-        `\n` +
-        `Change body\n`
+      'The message 1 is invalid:\n' +
+        '* The subject must start with a capitalized word, ' +
+        'but the current first word is: "change". ' +
+        'Please capitalize to: "Change".\n' +
+        'The original message was:\n' +
+        'change SomeClass to OtherClass\n\nDo something\n\n' +
+        'The message 2 is invalid:\n' +
+        '* The first word of the subject ("Change") must not match ' +
+        'the first word of the body. Please make the body more informative ' +
+        'by adding more information instead of repeating the subject. ' +
+        'For example, start by explaining the problem that this change ' +
+        'is intended to solve or what was previously missing ' +
+        '(e.g., "Previously, ....").\n' +
+        'The original message was:\n' +
+        'Change other subject\n\nChange body\n'
     ]
   ]);
 });

--- a/src/input.ts
+++ b/src/input.ts
@@ -1,3 +1,112 @@
+import fs from 'fs';
+
+export class Inputs {
+  public hasAdditionalVerbsInput: boolean;
+  public pathToAdditionalVerbs: string;
+  public allowOneLiners: boolean;
+
+  // This is a complete appendix to the whiltelist parsed both from
+  // the GitHub action input "additional-verbs" and from the file
+  // specified by the input "path-to-additional-verbs".
+  additionalVerbs: Set<string>;
+
+  constructor(
+    hasAdditionalVerbsInput: boolean,
+    pathToAdditionalVerbs: string,
+    allowOneLiners: boolean,
+    additionalVerbs: Set<string>
+  ) {
+    this.hasAdditionalVerbsInput = hasAdditionalVerbsInput;
+    this.pathToAdditionalVerbs = pathToAdditionalVerbs;
+    this.allowOneLiners = allowOneLiners;
+    this.additionalVerbs = additionalVerbs;
+  }
+}
+
+export class MaybeInputs {
+  public inputs: Inputs | null;
+  public error: string | null;
+
+  constructor(inputs: Inputs | null, error: string | null) {
+    if (inputs === null && error === null) {
+      throw Error("Unexpected both 'inputs' and 'error' arguments to be null.");
+    }
+
+    if (inputs !== null && error !== null) {
+      throw Error(
+        "Unexpected both 'inputs' and 'error' arguments to be given."
+      );
+    }
+
+    this.inputs = inputs;
+    this.error = error;
+  }
+
+  public mustInputs(): Inputs {
+    if (this.inputs === null) {
+      throw Error(
+        "The field 'inputs' is expected to be set, but it is null. " +
+          `The field 'error' is: ${this.error}`
+      );
+    }
+    return this.inputs;
+  }
+}
+
+export function parseInputs(
+  additionalVerbsInput: string,
+  pathToAdditionalVerbsInput: string,
+  allowOneLinersInput: string
+): MaybeInputs {
+  const additionalVerbs = new Set<string>();
+
+  const hasAdditionalVerbsInput = additionalVerbsInput.length > 0;
+
+  if (additionalVerbsInput) {
+    for (const verb of parseVerbs(additionalVerbsInput)) {
+      additionalVerbs.add(verb);
+    }
+  }
+
+  if (pathToAdditionalVerbsInput) {
+    if (!fs.existsSync(pathToAdditionalVerbsInput)) {
+      return new MaybeInputs(
+        null,
+        'The file referenced by path-to-additional-verbs could ' +
+          `not be found: ${pathToAdditionalVerbsInput}`
+      );
+    }
+
+    const text = fs.readFileSync(pathToAdditionalVerbsInput).toString('utf-8');
+
+    for (const verb of parseVerbs(text)) {
+      additionalVerbs.add(verb);
+    }
+  }
+
+  const allowOneLiners: boolean | null = !allowOneLinersInput
+    ? false
+    : parseAllowOneLiners(allowOneLinersInput);
+
+  if (allowOneLiners === null) {
+    return new MaybeInputs(
+      null,
+      'Unexpected value for allow-one-liners. ' +
+        `Expected either 'true' or 'false', got: ${allowOneLinersInput}`
+    );
+  }
+
+  return new MaybeInputs(
+    new Inputs(
+      hasAdditionalVerbsInput,
+      pathToAdditionalVerbsInput,
+      allowOneLiners,
+      additionalVerbs
+    ),
+    null
+  );
+}
+
 export function parseVerbs(text: string): string[] {
   const lines = text.split('\n');
 

--- a/src/mostFrequentEnglishVerbs.ts
+++ b/src/mostFrequentEnglishVerbs.ts
@@ -733,5 +733,6 @@ export const SET = new Set([
   'reinstate',
   'pin',
   'hint',
-  'integrate'
+  'integrate',
+  'instruct'
 ]);


### PR DESCRIPTION
In many teams, the wider team is not aware how the GitHub action has
been set up and merely sees the messages in their CI reports. These
users are ultimately lost and need further guidance on how to fix the
errors in their commit messages. In particular, sparse error messages
with no hints how to remedy the commit messages are almost useless
leaving the users utterly frustrated.

This change introduces very verbose error messages which include the
hints what can be done about the message. While the messages are now
quite long and seem cluttered, they are hopefully much more useful to
the inexperienced users.