### PR TITLE
Put latest full version in the Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check
-        uses: mristin/opinionated-commit-message@v2
+        uses: mristin/opinionated-commit-message@v2.2.0
 ```
 
 ## Checked Events


### PR DESCRIPTION
The Readme instructed the user to specify only
the major version, but that doesn't work any more.

Fixes #70 .