### PR TITLE
Add sign-off enforcement

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -20,3 +20,7 @@ inputs:
     description: 'If set to "true", allows one-liner commit messages without body'
     required: false
     default: ''
+  enforce-sign-off:
+    description: 'If set to "true", signed-off-by is required in the commit message body'
+    required: false
+    default: ''

--- a/src/__tests__/input.test.ts
+++ b/src/__tests__/input.test.ts
@@ -33,6 +33,7 @@ it('parses the inputs.', () => {
   const maybeInputs = input.parseInputs(
     'integrate\nanalyze',
     pathToVerbs,
+    'true',
     'true'
   );
 
@@ -45,4 +46,5 @@ it('parses the inputs.', () => {
     new Set<string>(['rewrap', 'table', 'integrate', 'analyze'])
   );
   expect(inputs.allowOneLiners).toBeTruthy();
+  expect(inputs.enforceSignOff).toBeTruthy();
 });

--- a/src/input.ts
+++ b/src/input.ts
@@ -10,16 +10,20 @@ export class Inputs {
   // specified by the input "path-to-additional-verbs".
   additionalVerbs: Set<string>;
 
+  public enforceSignOff: boolean;
+
   constructor(
     hasAdditionalVerbsInput: boolean,
     pathToAdditionalVerbs: string,
     allowOneLiners: boolean,
-    additionalVerbs: Set<string>
+    additionalVerbs: Set<string>,
+    enforceSignOff: boolean
   ) {
     this.hasAdditionalVerbsInput = hasAdditionalVerbsInput;
     this.pathToAdditionalVerbs = pathToAdditionalVerbs;
     this.allowOneLiners = allowOneLiners;
     this.additionalVerbs = additionalVerbs;
+    this.enforceSignOff = enforceSignOff;
   }
 }
 
@@ -56,7 +60,8 @@ export class MaybeInputs {
 export function parseInputs(
   additionalVerbsInput: string,
   pathToAdditionalVerbsInput: string,
-  allowOneLinersInput: string
+  allowOneLinersInput: string,
+  enforceSignOffInput: string
 ): MaybeInputs {
   const additionalVerbs = new Set<string>();
 
@@ -86,7 +91,7 @@ export function parseInputs(
 
   const allowOneLiners: boolean | null = !allowOneLinersInput
     ? false
-    : parseAllowOneLiners(allowOneLinersInput);
+    : parseBooleanFromString(allowOneLinersInput);
 
   if (allowOneLiners === null) {
     return new MaybeInputs(
@@ -96,12 +101,25 @@ export function parseInputs(
     );
   }
 
+  const enforceSignOff: boolean | null = !enforceSignOffInput
+    ? false
+    : parseBooleanFromString(enforceSignOffInput);
+
+  if (enforceSignOff === null) {
+    return new MaybeInputs(
+      null,
+      'Unexpected value for enforce-sign-off. ' +
+        `Expected either 'true' or 'false', got: ${enforceSignOffInput}`
+    );
+  }
+
   return new MaybeInputs(
     new Inputs(
       hasAdditionalVerbsInput,
       pathToAdditionalVerbsInput,
       allowOneLiners,
-      additionalVerbs
+      additionalVerbs,
+      enforceSignOff
     ),
     null
   );
@@ -123,7 +141,7 @@ export function parseVerbs(text: string): string[] {
   return verbs;
 }
 
-export function parseAllowOneLiners(text: string): boolean | null {
+function parseBooleanFromString(text: string): boolean | null {
   if (text === '' || text.toLowerCase() === 'false' || text === '0') {
     return false;
   }

--- a/src/inspection.ts
+++ b/src/inspection.ts
@@ -265,6 +265,30 @@ function checkBody(subject: string, bodyLines: string[]): string[] {
   return errors;
 }
 
+const signedOffByRe = new RegExp(
+  '^\\s*Signed-off-by:\\s*[^<]+\\s*<[^@>, ]+@[^@>, ]+>\\s*$'
+);
+
+function checkSignedOff(bodyLines: string[]): string[] {
+  const errors: string[] = [];
+
+  let matches = 0;
+  for (const line of bodyLines) {
+    if (signedOffByRe.test(line)) {
+      matches++;
+    }
+  }
+
+  if (matches === 0) {
+    errors.push(
+      "The body does not contain any 'Signed-off-by: ' line. " +
+        'Did you sign off the commit with `git commit --signoff`?'
+    );
+  }
+
+  return errors;
+}
+
 const mergeMessageRe = new RegExp(
   "^Merge branch '[^\\000-\\037\\177 ~^:?*[]+' " +
     'into [^\\000-\\037\\177 ~^:?*[]+$'
@@ -297,6 +321,10 @@ export function check(message: string, inputs: input.Inputs): string[] {
       errors.push(...checkSubject(subjectBody.subject, inputs));
 
       errors.push(...checkBody(subjectBody.subject, subjectBody.bodyLines));
+
+      if (inputs.enforceSignOff) {
+        errors.push(...checkSignedOff(subjectBody.bodyLines));
+      }
     }
   }
 

--- a/src/mainImpl.ts
+++ b/src/mainImpl.ts
@@ -21,10 +21,14 @@ function runWithExceptions(): void {
   const allowOneLinersInput =
     core.getInput('allow-one-liners', {required: false}) ?? '';
 
+  const enforceSignOffInput =
+    core.getInput('enforce-sign-off', {required: false}) ?? '';
+
   const maybeInputs = input.parseInputs(
     additionalVerbsInput,
     pathToAdditionalVerbsInput,
-    allowOneLinersInput
+    allowOneLinersInput,
+    enforceSignOffInput
   );
 
   if (maybeInputs.error !== null) {


### PR DESCRIPTION
This patch adds a flag to enforce a sign-off of a commit. See [1] for
more information.

Fixes #73.

[1]: https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff