### PR TITLE
Bump `@actions/core` to 1.2.6 for security

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@mristin/opinionated-commit-message",
-  "version": "2.0.0-pre3",
+  "version": "2.3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@actions/core": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.2.4.tgz",
-      "integrity": "sha512-YJCEq8BE3CdN8+7HPZ/4DxJjk/OkZV2FFIf+DlZTC/4iBlzYCD5yjRR6eiOS5llO11zbRltIRuKAjMKaWTE6cg=="
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.5.0.tgz",
+      "integrity": "sha512-eDOLH1Nq9zh+PJlYLqEMkS/jLQxhksPNmUGNBHfa4G+tQmnIhzpctxmchETtVGyBOvXgOVVpYuE40+eS4cUnwQ=="
     },
     "@actions/github": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "all": "npm run build && npm run format && npm run lint && npm run pack && npm run to-powershell && npm test"
   },
   "dependencies": {
-    "@actions/core": "^1.2.4",
+    "@actions/core": "^1.2.6",
     "@actions/github": "^2.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Dependabot alerted us that the dependency `@actions/core` need to be
updated to a newer version.