### PR TITLE
Make max length of body lines configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,23 @@ You can allow one-liner commit messages by setting the flag `allow-one-liners`:
           allow-one-liners: 'true'
 ```
 
+## Custom line length on the body
+
+For terminal use and for some GUIs with a columnar and monospaced history it is a good practice to limit the length
+of body lines to 72 characters. For teams that use only modern UIs such as GitHub Web this is a harsh restriction,
+especially when using a PR description as the body, where the workflow can become quite confusing since there is no
+limitation on the UI itself.
+
+You can change the default line length by setting the flag `max-body-line-length`:
+
+```yaml
+    steps:
+      - name: Check
+        uses: mristin/opinionated-commit-message@v2
+        with:
+          max-body-line-length: '100'
+```
+
 ## Skip Body Check
 
 For some repositories only the subject matters while the body is allowed to be free-form.

--- a/README.md
+++ b/README.md
@@ -160,12 +160,11 @@ You can allow one-liner commit messages by setting the flag `allow-one-liners`:
 
 ## Custom line length on the body
 
-For terminal use and for some GUIs with a columnar and monospaced history it is a good practice to limit the length
-of body lines to 72 characters. For teams that use only modern UIs such as GitHub Web this is a harsh restriction,
-especially when using a PR description as the body, where the workflow can become quite confusing since there is no
-limitation on the UI itself.
+For use in terminals and monospaced GUIs it is a good practice to limit the line length of the body to 72 characters.
+However, the restriction is unnecessarily harsh for teams that use modern GUIs such as GitHub Web.
+This is especially so when using a description of the pull request as the body, since there is no such limitation in the GitHub UI itself.
 
-You can change the default line length by setting the flag `max-body-line-length`:
+You can change the imposed maximum line length by setting the flag `max-body-line-length`:
 
 ```yaml
     steps:

--- a/README.md
+++ b/README.md
@@ -158,9 +158,23 @@ You can allow one-liner commit messages by setting the flag `allow-one-liners`:
           allow-one-liners: 'true'
 ```
 
+## Custom subject length
+
+For use in terminals and monospaced GUIs it is a good practice to limit length of the subject to 50 characters.
+
+You can change the imposed maximum subject length by setting the flag `max-subject-line-length`:
+
+```yaml
+    steps:
+      - name: Check
+        uses: mristin/opinionated-commit-message@v2
+        with:
+          max-subject-line-length: '100'
+```
+
 ## Custom line length on the body
 
-For use in terminals and monospaced GUIs it is a good practice to limit the line length of the body to 72 characters.
+Similar to the subject line, for terminals and monospaced GUIs it is a good practice to limit the line length of the body to 72 characters.
 However, the restriction is unnecessarily harsh for teams that use modern GUIs such as GitHub Web.
 This is especially so when using a description of the pull request as the body, since there is no such limitation in the GitHub UI itself.
 

--- a/README.md
+++ b/README.md
@@ -161,6 +161,8 @@ You can allow one-liner commit messages by setting the flag `allow-one-liners`:
 ## Custom subject length
 
 For use in terminals and monospaced GUIs it is a good practice to limit length of the subject to 50 characters.
+For some projects, though, this limit is too restrictive.
+For example, if you include tags in the subject (such as `[FIX]`) there is not much space left for the actual subject.
 
 You can change the imposed maximum subject length by setting the flag `max-subject-line-length`:
 

--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,10 @@ inputs:
     description: 'If set to "true", allows one-liner commit messages without body'
     required: false
     default: ''
+  max-subject-line-length:
+    description: 'Maximum length of the commit subject line'
+    required: false
+    default: ''
   max-body-line-length:
     description: 'Maximum length of a line in the body of the commit message'
     required: false

--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,10 @@ inputs:
     description: 'If set to "true", allows one-liner commit messages without body'
     required: false
     default: ''
+  max-body-line-length:
+    description: 'Maximum length of a line in the body of the commit message'
+    required: false
+    default: ''
   enforce-sign-off:
     description: 'If set to "true", signed-off-by is required in the commit message body'
     required: false

--- a/src/__tests__/input.test.ts
+++ b/src/__tests__/input.test.ts
@@ -34,6 +34,7 @@ it('parses the inputs.', () => {
     'integrate\nanalyze',
     pathToVerbs,
     'true',
+    '90',
     '100',
     'true',
     'true'
@@ -48,6 +49,7 @@ it('parses the inputs.', () => {
     new Set<string>(['rewrap', 'table', 'integrate', 'analyze'])
   );
   expect(inputs.allowOneLiners).toBeTruthy();
+  expect(inputs.maxSubjectLength).toEqual(90);
   expect(inputs.maxBodyLineLength).toEqual(100);
   expect(inputs.enforceSignOff).toBeTruthy();
   expect(inputs.skipBodyCheck).toBeTruthy();

--- a/src/__tests__/input.test.ts
+++ b/src/__tests__/input.test.ts
@@ -34,6 +34,7 @@ it('parses the inputs.', () => {
     'integrate\nanalyze',
     pathToVerbs,
     'true',
+    '100',
     'true',
     'true'
   );
@@ -47,6 +48,7 @@ it('parses the inputs.', () => {
     new Set<string>(['rewrap', 'table', 'integrate', 'analyze'])
   );
   expect(inputs.allowOneLiners).toBeTruthy();
+  expect(inputs.maxBodyLineLength).toEqual(100);
   expect(inputs.enforceSignOff).toBeTruthy();
   expect(inputs.skipBodyCheck).toBeTruthy();
 });

--- a/src/__tests__/inspection.test.ts
+++ b/src/__tests__/inspection.test.ts
@@ -2,7 +2,7 @@ import * as input from '../input';
 import * as inspection from '../inspection';
 
 const defaultInputs: input.Inputs = input
-  .parseInputs('', '', '', '', '', '')
+  .parseInputs('', '', '', '', '', '', '')
   .mustInputs();
 
 it('reports no errors on correct multi-line message.', () => {
@@ -28,7 +28,7 @@ it('reports no errors on OK multi-line message with allowed one-liners.', () => 
 });
 
 it('reports no errors on OK single-line message with allowed one-liners.', () => {
-  const inputs = input.parseInputs('', '', 'true', '', '', '').mustInputs();
+  const inputs = input.parseInputs('', '', 'true', '', '', '', '').mustInputs();
 
   const message = 'Change SomeClass to OtherClass';
 
@@ -63,12 +63,14 @@ it('reports no errors on any message when body check is disabled.', () => {
     'since Some class was deprecated. This is long message should not ' +
     'be checked.';
 
-  const inputCheckingBody = input.parseInputs('', '', '', '', '').mustInputs();
+  const inputCheckingBody = input
+    .parseInputs('', '', '', '', '', '', '')
+    .mustInputs();
 
   expect(inspection.check(message, inputCheckingBody)).not.toEqual([]);
 
   const inputNotCheckingBody = input
-    .parseInputs('', '', '', '', 'true')
+    .parseInputs('', '', '', '', '', '', 'true')
     .mustInputs();
 
   expect(inspection.check(message, inputNotCheckingBody)).toEqual([]);
@@ -81,7 +83,7 @@ it('reports missing body with disallowed one-liners.', () => {
 });
 
 it('reports missing body with allowed one-liners.', () => {
-  const inputs = input.parseInputs('', '', 'true', '', '', '').mustInputs();
+  const inputs = input.parseInputs('', '', 'true', '', '', '', '').mustInputs();
 
   const message = 'Change SomeClass to OtherClass\n';
   const errors = inspection.check(message, inputs);
@@ -168,7 +170,7 @@ it(
     'with additional verbs given as direct input.',
   () => {
     const inputs = input
-      .parseInputs('table', '', 'false', '', '', '')
+      .parseInputs('table', '', 'false', '', '', '', '')
       .mustInputs();
 
     const message =
@@ -242,7 +244,7 @@ it(
 
 it('accepts the subject starting with an additional verb.', () => {
   const inputs = input
-    .parseInputs('table', '', 'false', '', '', '')
+    .parseInputs('table', '', 'false', '', '', '', '')
     .mustInputs();
 
   const message = 'Table that for me\n\nThis is a dummy commit.';
@@ -265,7 +267,7 @@ it('reports the subject ending in a dot.', () => {
 });
 
 it('reports an incorrect one-line message with allowed one-liners.', () => {
-  const inputs = input.parseInputs('', '', 'true', '', '', '').mustInputs();
+  const inputs = input.parseInputs('', '', 'true', '', '', '', '').mustInputs();
 
   const message = 'Change SomeClass to OtherClass.';
 
@@ -298,7 +300,7 @@ it('reports too long a subject line with custom max length.', () => {
     'This replaces the SomeClass with OtherClass in all of the module\n' +
     'since Some class was deprecated.';
 
-  const inputs = input.parseInputs('', '', '', '60', '', '').mustInputs();
+  const inputs = input.parseInputs('', '', '', '60', '', '', '').mustInputs();
 
   const errors = inspection.check(message, inputs);
   expect(errors).toEqual([
@@ -332,7 +334,7 @@ it('reports too long a body line with custom max length.', () => {
     'This replaces the SomeClass with OtherClass in all of the module ' +
     'since Some class was deprecated.';
 
-  const inputs = input.parseInputs('', '', '', '', '90', '').mustInputs();
+  const inputs = input.parseInputs('', '', '', '', '90', '', '').mustInputs();
 
   const errors = inspection.check(message, inputs);
   expect(errors).toEqual([

--- a/src/__tests__/inspection.test.ts
+++ b/src/__tests__/inspection.test.ts
@@ -205,6 +205,7 @@ it(
       '/some/path',
       false,
       new Set<string>('table'),
+      72,
       false,
       false
     );
@@ -284,6 +285,25 @@ it('reports too long a body line.', () => {
       '"This replaces the SomeClass with OtherClass in all of the module since ' +
       'Some class was deprecated.". ' +
       'Please reformat the body so that all the lines fit 72 characters.'
+  ]);
+});
+
+it('reports too long a body line with custom max length.', () => {
+  const message =
+    'Change SomeClass to OtherClass\n' +
+    '\n' +
+    'This replaces the SomeClass with OtherClass in all of the module ' +
+    'since Some class was deprecated.';
+
+  const inputs = input.parseInputs('', '', '', '90', '').mustInputs();
+
+  const errors = inspection.check(message, inputs);
+  expect(errors).toEqual([
+    'The line 3 of the message (line 1 of the body) exceeds the limit of ' +
+      '90 characters. The line contains 97 characters: ' +
+      '"This replaces the SomeClass with OtherClass in all of the module since ' +
+      'Some class was deprecated.". ' +
+      'Please reformat the body so that all the lines fit 90 characters.'
   ]);
 });
 
@@ -434,7 +454,7 @@ The ${long} line is too long.`;
 });
 
 it('accepts the valid body when enforcing the sign-off.', () => {
-  const inputs = input.parseInputs('', '', '', 'true', '').mustInputs();
+  const inputs = input.parseInputs('', '', '', '', 'true', '').mustInputs();
 
   const message = `Do something
 
@@ -453,7 +473,7 @@ Signed-off-by: Somebody Else <some@body-else.com>
 });
 
 it('rejects invalid sign-offs.', () => {
-  const inputs = input.parseInputs('', '', '', 'true', '').mustInputs();
+  const inputs = input.parseInputs('', '', '', '', 'true', '').mustInputs();
 
   const message = `Do something
 

--- a/src/__tests__/inspection.test.ts
+++ b/src/__tests__/inspection.test.ts
@@ -2,7 +2,7 @@ import * as input from '../input';
 import * as inspection from '../inspection';
 
 const defaultInputs: input.Inputs = input
-  .parseInputs('', '', '', '', '')
+  .parseInputs('', '', '', '', '', '')
   .mustInputs();
 
 it('reports no errors on correct multi-line message.', () => {
@@ -28,7 +28,7 @@ it('reports no errors on OK multi-line message with allowed one-liners.', () => 
 });
 
 it('reports no errors on OK single-line message with allowed one-liners.', () => {
-  const inputs = input.parseInputs('', '', 'true', '', '').mustInputs();
+  const inputs = input.parseInputs('', '', 'true', '', '', '').mustInputs();
 
   const message = 'Change SomeClass to OtherClass';
 
@@ -81,7 +81,7 @@ it('reports missing body with disallowed one-liners.', () => {
 });
 
 it('reports missing body with allowed one-liners.', () => {
-  const inputs = input.parseInputs('', '', 'true', '', '').mustInputs();
+  const inputs = input.parseInputs('', '', 'true', '', '', '').mustInputs();
 
   const message = 'Change SomeClass to OtherClass\n';
   const errors = inspection.check(message, inputs);
@@ -167,7 +167,9 @@ it(
   'reports the subject starting with a non-verb ' +
     'with additional verbs given as direct input.',
   () => {
-    const inputs = input.parseInputs('table', '', 'false', '', '').mustInputs();
+    const inputs = input
+      .parseInputs('table', '', 'false', '', '', '')
+      .mustInputs();
 
     const message =
       'Replaced SomeClass to OtherClass\n' +
@@ -205,6 +207,7 @@ it(
       '/some/path',
       false,
       new Set<string>('table'),
+      50,
       72,
       false,
       false
@@ -238,7 +241,9 @@ it(
 );
 
 it('accepts the subject starting with an additional verb.', () => {
-  const inputs = input.parseInputs('table', '', 'false', '', '').mustInputs();
+  const inputs = input
+    .parseInputs('table', '', 'false', '', '', '')
+    .mustInputs();
 
   const message = 'Table that for me\n\nThis is a dummy commit.';
   const errors = inspection.check(message, inputs);
@@ -260,7 +265,7 @@ it('reports the subject ending in a dot.', () => {
 });
 
 it('reports an incorrect one-line message with allowed one-liners.', () => {
-  const inputs = input.parseInputs('', '', 'true', '', '').mustInputs();
+  const inputs = input.parseInputs('', '', 'true', '', '', '').mustInputs();
 
   const message = 'Change SomeClass to OtherClass.';
 
@@ -268,6 +273,38 @@ it('reports an incorrect one-line message with allowed one-liners.', () => {
   expect(errors).toEqual([
     "The subject must not end with a dot ('.'). " +
       'Please remove the trailing dot(s).'
+  ]);
+});
+
+it('reports too long a subject line.', () => {
+  const message =
+    'Change SomeClass to OtherClass in order to handle upstream deprecation\n' +
+    '\n' +
+    'This replaces the SomeClass with OtherClass in all of the module\n' +
+    'since Some class was deprecated.';
+
+  const errors = inspection.check(message, defaultInputs);
+  expect(errors).toEqual([
+    `The subject exceeds the limit of 50 characters ` +
+      `(got: 70, JSON: "Change SomeClass to OtherClass in order to handle upstream deprecation").` +
+      'Please shorten the subject to make it more succinct.'
+  ]);
+});
+
+it('reports too long a subject line with custom max length.', () => {
+  const message =
+    'Change SomeClass to OtherClass in order to handle upstream deprecation\n' +
+    '\n' +
+    'This replaces the SomeClass with OtherClass in all of the module\n' +
+    'since Some class was deprecated.';
+
+  const inputs = input.parseInputs('', '', '', '60', '', '').mustInputs();
+
+  const errors = inspection.check(message, inputs);
+  expect(errors).toEqual([
+    `The subject exceeds the limit of 60 characters ` +
+      `(got: 70, JSON: "Change SomeClass to OtherClass in order to handle upstream deprecation").` +
+      'Please shorten the subject to make it more succinct.'
   ]);
 });
 
@@ -295,7 +332,7 @@ it('reports too long a body line with custom max length.', () => {
     'This replaces the SomeClass with OtherClass in all of the module ' +
     'since Some class was deprecated.';
 
-  const inputs = input.parseInputs('', '', '', '90', '').mustInputs();
+  const inputs = input.parseInputs('', '', '', '', '90', '').mustInputs();
 
   const errors = inspection.check(message, inputs);
   expect(errors).toEqual([
@@ -454,7 +491,7 @@ The ${long} line is too long.`;
 });
 
 it('accepts the valid body when enforcing the sign-off.', () => {
-  const inputs = input.parseInputs('', '', '', '', 'true', '').mustInputs();
+  const inputs = input.parseInputs('', '', '', '', '', 'true', '').mustInputs();
 
   const message = `Do something
 
@@ -473,7 +510,7 @@ Signed-off-by: Somebody Else <some@body-else.com>
 });
 
 it('rejects invalid sign-offs.', () => {
-  const inputs = input.parseInputs('', '', '', '', 'true', '').mustInputs();
+  const inputs = input.parseInputs('', '', '', '', '', 'true', '').mustInputs();
 
   const message = `Do something
 

--- a/src/input.ts
+++ b/src/input.ts
@@ -4,6 +4,7 @@ export class Inputs {
   public hasAdditionalVerbsInput: boolean;
   public pathToAdditionalVerbs: string;
   public allowOneLiners: boolean;
+  public maxSubjectLength: number;
   public maxBodyLineLength: number;
   public skipBodyCheck: boolean;
 
@@ -19,6 +20,7 @@ export class Inputs {
     pathToAdditionalVerbs: string,
     allowOneLiners: boolean,
     additionalVerbs: Set<string>,
+    maxSubjectLength: number,
     maxBodyLineLength: number,
     enforceSignOff: boolean,
     skipBodyCheck: boolean
@@ -27,6 +29,7 @@ export class Inputs {
     this.pathToAdditionalVerbs = pathToAdditionalVerbs;
     this.allowOneLiners = allowOneLiners;
     this.additionalVerbs = additionalVerbs;
+    this.maxSubjectLength = maxSubjectLength;
     this.maxBodyLineLength = maxBodyLineLength;
     this.enforceSignOff = enforceSignOff;
     this.skipBodyCheck = skipBodyCheck;
@@ -67,6 +70,7 @@ export function parseInputs(
   additionalVerbsInput: string,
   pathToAdditionalVerbsInput: string,
   allowOneLinersInput: string,
+  maxSubjectLengthInput: string,
   maxBodyLineLengthInput: string,
   enforceSignOffInput: string,
   skipBodyCheckInput: string
@@ -109,6 +113,18 @@ export function parseInputs(
     );
   }
 
+  const maxSubjectLength: number = !maxSubjectLengthInput
+    ? 50
+    : parseInt(maxSubjectLengthInput, 10);
+
+  if (Number.isNaN(maxSubjectLength)) {
+    return new MaybeInputs(
+      null,
+      'Unexpected value for max-subject-line-length. ' +
+        `Expected a number or nothing, got ${maxSubjectLengthInput}`
+    );
+  }
+
   const maxBodyLineLength: number = !maxBodyLineLengthInput
     ? 72
     : parseInt(maxBodyLineLengthInput, 10);
@@ -116,7 +132,7 @@ export function parseInputs(
   if (Number.isNaN(maxBodyLineLength)) {
     return new MaybeInputs(
       null,
-      'Unexpected value for body-line-length. ' +
+      'Unexpected value for max-body-line-length. ' +
         `Expected a number or nothing, got ${maxBodyLineLengthInput}`
     );
   }
@@ -151,6 +167,7 @@ export function parseInputs(
       pathToAdditionalVerbsInput,
       allowOneLiners,
       additionalVerbs,
+      maxSubjectLength,
       maxBodyLineLength,
       enforceSignOff,
       skipBodyCheck

--- a/src/input.ts
+++ b/src/input.ts
@@ -4,6 +4,7 @@ export class Inputs {
   public hasAdditionalVerbsInput: boolean;
   public pathToAdditionalVerbs: string;
   public allowOneLiners: boolean;
+  public maxBodyLineLength: number;
   public skipBodyCheck: boolean;
 
   // This is a complete appendix to the whiltelist parsed both from
@@ -18,6 +19,7 @@ export class Inputs {
     pathToAdditionalVerbs: string,
     allowOneLiners: boolean,
     additionalVerbs: Set<string>,
+    maxBodyLineLength: number,
     enforceSignOff: boolean,
     skipBodyCheck: boolean
   ) {
@@ -25,6 +27,7 @@ export class Inputs {
     this.pathToAdditionalVerbs = pathToAdditionalVerbs;
     this.allowOneLiners = allowOneLiners;
     this.additionalVerbs = additionalVerbs;
+    this.maxBodyLineLength = maxBodyLineLength;
     this.enforceSignOff = enforceSignOff;
     this.skipBodyCheck = skipBodyCheck;
   }
@@ -64,6 +67,7 @@ export function parseInputs(
   additionalVerbsInput: string,
   pathToAdditionalVerbsInput: string,
   allowOneLinersInput: string,
+  maxBodyLineLengthInput: string,
   enforceSignOffInput: string,
   skipBodyCheckInput: string
 ): MaybeInputs {
@@ -105,6 +109,18 @@ export function parseInputs(
     );
   }
 
+  const maxBodyLineLength: number = !maxBodyLineLengthInput
+    ? 72
+    : parseInt(maxBodyLineLengthInput, 10);
+
+  if (Number.isNaN(maxBodyLineLength)) {
+    return new MaybeInputs(
+      null,
+      'Unexpected value for body-line-length. ' +
+        `Expected a number or nothing, got ${maxBodyLineLengthInput}`
+    );
+  }
+
   const enforceSignOff: boolean | null = !enforceSignOffInput
     ? false
     : parseBooleanFromString(enforceSignOffInput);
@@ -135,6 +151,7 @@ export function parseInputs(
       pathToAdditionalVerbsInput,
       allowOneLiners,
       additionalVerbs,
+      maxBodyLineLength,
       enforceSignOff,
       skipBodyCheck
     ),

--- a/src/inspection.ts
+++ b/src/inspection.ts
@@ -325,7 +325,9 @@ export function check(message: string, inputs: input.Inputs): string[] {
       errors.push(...checkSubject(subjectBody.subject, inputs));
 
       if (!inputs.skipBodyCheck) {
-        errors.push(...checkBody(subjectBody.subject, subjectBody.bodyLines, inputs));
+        errors.push(
+          ...checkBody(subjectBody.subject, subjectBody.bodyLines, inputs)
+        );
       }
 
       if (inputs.enforceSignOff) {

--- a/src/inspection.ts
+++ b/src/inspection.ts
@@ -209,7 +209,11 @@ function checkSubject(subject: string, inputs: input.Inputs): string[] {
 const urlLineRe = new RegExp('^[^ ]+://[^ ]+$');
 const linkDefinitionRe = new RegExp('^\\[[^\\]]+]\\s*:\\s*[^ ]+://[^ ]+$');
 
-function checkBody(subject: string, bodyLines: string[]): string[] {
+function checkBody(
+  subject: string,
+  bodyLines: string[],
+  inputs: input.Inputs
+): string[] {
   const errors: string[] = [];
 
   if (bodyLines.length === 0) {
@@ -229,14 +233,14 @@ function checkBody(subject: string, bodyLines: string[]): string[] {
       continue;
     }
 
-    if (line.length > 72) {
+    if (line.length > inputs.maxBodyLineLength) {
       errors.push(
         `The line ${i + 3} of the message (line ${i + 1} of the body) ` +
-          'exceeds the limit of 72 characters. ' +
+          `exceeds the limit of ${inputs.maxBodyLineLength} characters. ` +
           `The line contains ${line.length} characters: ` +
           `${JSON.stringify(line)}. ` +
           'Please reformat the body so that all the lines fit ' +
-          '72 characters.'
+          `${inputs.maxBodyLineLength} characters.`
       );
     }
   }
@@ -321,7 +325,7 @@ export function check(message: string, inputs: input.Inputs): string[] {
       errors.push(...checkSubject(subjectBody.subject, inputs));
 
       if (!inputs.skipBodyCheck) {
-        errors.push(...checkBody(subjectBody.subject, subjectBody.bodyLines));
+        errors.push(...checkBody(subjectBody.subject, subjectBody.bodyLines, inputs));
       }
 
       if (inputs.enforceSignOff) {

--- a/src/inspection.ts
+++ b/src/inspection.ts
@@ -151,9 +151,9 @@ function checkSubject(subject: string, inputs: input.Inputs): string[] {
   // similar services.
   const subjectWoCode = subject.replace(suffixHashCodeRe, '');
 
-  if (subjectWoCode.length > 50) {
+  if (subjectWoCode.length > inputs.maxSubjectLength) {
     errors.push(
-      `The subject exceeds the limit of 50 characters ` +
+      `The subject exceeds the limit of ${inputs.maxSubjectLength} characters ` +
         `(got: ${subject.length}, JSON: ${JSON.stringify(subjectWoCode)}).` +
         'Please shorten the subject to make it more succinct.'
     );

--- a/src/mainImpl.ts
+++ b/src/mainImpl.ts
@@ -21,6 +21,9 @@ function runWithExceptions(): void {
   const allowOneLinersInput =
     core.getInput('allow-one-liners', {required: false}) ?? '';
 
+  const maxSubjectLengthInput =
+    core.getInput('max-subject-line-length', {required: false}) ?? '';
+
   const maxBodyLineLengthInput =
     core.getInput('max-body-line-length', {required: false}) ?? '';
 
@@ -34,6 +37,7 @@ function runWithExceptions(): void {
     additionalVerbsInput,
     pathToAdditionalVerbsInput,
     allowOneLinersInput,
+    maxSubjectLengthInput,
     maxBodyLineLengthInput,
     enforceSignOffInput,
     skipBodyCheckInput

--- a/src/mainImpl.ts
+++ b/src/mainImpl.ts
@@ -21,6 +21,9 @@ function runWithExceptions(): void {
   const allowOneLinersInput =
     core.getInput('allow-one-liners', {required: false}) ?? '';
 
+  const maxBodyLineLengthInput =
+    core.getInput('max-body-line-length', {required: false}) ?? '';
+
   const enforceSignOffInput =
     core.getInput('enforce-sign-off', {required: false}) ?? '';
 
@@ -31,6 +34,7 @@ function runWithExceptions(): void {
     additionalVerbsInput,
     pathToAdditionalVerbsInput,
     allowOneLinersInput,
+    maxBodyLineLengthInput,
     enforceSignOffInput,
     skipBodyCheckInput
   );


### PR DESCRIPTION
The limit of 72 characters is great for strict terminal use and some
GUIs, but for teams that use only UIs such as GitHub Web it is an
unnecessary and harsh restriction.
This PR adds a `max-body-line-length` option to make this
configurable.

Signed-off-by: Luiz Ferraz <luiz.ferraz@croct.com>