### PR TITLE
Allow skipping message body check

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,13 +149,29 @@ and more verbose body for an informative Git history. However, this might be
 too rigid for certain projects.
 
 You can allow one-liner commit messages by setting the flag `allow-one-liners`:
-
+ 
 ```yaml
     steps:
       - name: Check
         uses: mristin/opinionated-commit-message@v2
         with:
           allow-one-liners: 'true'
+```
+
+## Skip Body Check
+
+For some repositories only the subject matters while the body is allowed to be free-form.
+For example, this is the case when the body of the commit is automatically generated (*e.g.*, by a third-party service that we do not control).
+In such situations, we want check the subject line, but ignore the body in the checks.
+
+You can disable checking the body by setting the flag `skip-body-check`:
+
+```yaml
+    steps:
+      - name: Check
+        uses: mristin/opinionated-commit-message@v2
+        with:
+          skip-body-check: 'true'
 ```
 
 ## Enforce Sign-off

--- a/action.yml
+++ b/action.yml
@@ -24,3 +24,7 @@ inputs:
     description: 'If set to "true", signed-off-by is required in the commit message body'
     required: false
     default: ''
+  skip-body-check:
+    description: 'If set to "true", skip the body check'
+    required: false
+    default: ''

--- a/dist/index.js
+++ b/dist/index.js
@@ -536,7 +536,9 @@ function check(message, inputs) {
             }
             const subjectBody = maybeSubjectBody.subjectBody;
             errors.push(...checkSubject(subjectBody.subject, inputs));
-            errors.push(...checkBody(subjectBody.subject, subjectBody.bodyLines));
+            if (!inputs.skipBodyCheck) {
+                errors.push(...checkBody(subjectBody.subject, subjectBody.bodyLines));
+            }
             if (inputs.enforceSignOff) {
                 errors.push(...checkSignedOff(subjectBody.bodyLines));
             }
@@ -1265,12 +1267,13 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.parseVerbs = exports.parseInputs = exports.MaybeInputs = exports.Inputs = void 0;
 const fs_1 = __importDefault(__webpack_require__(747));
 class Inputs {
-    constructor(hasAdditionalVerbsInput, pathToAdditionalVerbs, allowOneLiners, additionalVerbs, enforceSignOff) {
+    constructor(hasAdditionalVerbsInput, pathToAdditionalVerbs, allowOneLiners, additionalVerbs, enforceSignOff, skipBodyCheck) {
         this.hasAdditionalVerbsInput = hasAdditionalVerbsInput;
         this.pathToAdditionalVerbs = pathToAdditionalVerbs;
         this.allowOneLiners = allowOneLiners;
         this.additionalVerbs = additionalVerbs;
         this.enforceSignOff = enforceSignOff;
+        this.skipBodyCheck = skipBodyCheck;
     }
 }
 exports.Inputs = Inputs;
@@ -1294,7 +1297,7 @@ class MaybeInputs {
     }
 }
 exports.MaybeInputs = MaybeInputs;
-function parseInputs(additionalVerbsInput, pathToAdditionalVerbsInput, allowOneLinersInput, enforceSignOffInput) {
+function parseInputs(additionalVerbsInput, pathToAdditionalVerbsInput, allowOneLinersInput, enforceSignOffInput, skipBodyCheckInput) {
     const additionalVerbs = new Set();
     const hasAdditionalVerbsInput = additionalVerbsInput.length > 0;
     if (additionalVerbsInput) {
@@ -1326,7 +1329,14 @@ function parseInputs(additionalVerbsInput, pathToAdditionalVerbsInput, allowOneL
         return new MaybeInputs(null, 'Unexpected value for enforce-sign-off. ' +
             `Expected either 'true' or 'false', got: ${enforceSignOffInput}`);
     }
-    return new MaybeInputs(new Inputs(hasAdditionalVerbsInput, pathToAdditionalVerbsInput, allowOneLiners, additionalVerbs, enforceSignOff), null);
+    const skipBodyCheck = !skipBodyCheckInput
+        ? false
+        : parseBooleanFromString(skipBodyCheckInput);
+    if (skipBodyCheck === null) {
+        return new MaybeInputs(null, 'Unexpected value for skip-body-check. ' +
+            `Expected either 'true' or 'false', got: ${skipBodyCheckInput}`);
+    }
+    return new MaybeInputs(new Inputs(hasAdditionalVerbsInput, pathToAdditionalVerbsInput, allowOneLiners, additionalVerbs, enforceSignOff, skipBodyCheck), null);
 }
 exports.parseInputs = parseInputs;
 function parseVerbs(text) {
@@ -1724,7 +1734,7 @@ const inspection = __importStar(__webpack_require__(117));
 const represent = __importStar(__webpack_require__(110));
 const input = __importStar(__webpack_require__(265));
 function runWithExceptions() {
-    var _a, _b, _c, _d;
+    var _a, _b, _c, _d, _e;
     const messages = commitMessages.retrieve();
     ////
     // Parse inputs
@@ -1733,7 +1743,8 @@ function runWithExceptions() {
     const pathToAdditionalVerbsInput = (_b = core.getInput('path-to-additional-verbs', { required: false })) !== null && _b !== void 0 ? _b : '';
     const allowOneLinersInput = (_c = core.getInput('allow-one-liners', { required: false })) !== null && _c !== void 0 ? _c : '';
     const enforceSignOffInput = (_d = core.getInput('enforce-sign-off', { required: false })) !== null && _d !== void 0 ? _d : '';
-    const maybeInputs = input.parseInputs(additionalVerbsInput, pathToAdditionalVerbsInput, allowOneLinersInput, enforceSignOffInput);
+    const skipBodyCheckInput = (_e = core.getInput('skip-body-check', { required: false })) !== null && _e !== void 0 ? _e : '';
+    const maybeInputs = input.parseInputs(additionalVerbsInput, pathToAdditionalVerbsInput, allowOneLinersInput, enforceSignOffInput, skipBodyCheckInput);
     if (maybeInputs.error !== null) {
         core.error(maybeInputs.error);
         core.setFailed(maybeInputs.error);

--- a/src/__tests__/input.test.ts
+++ b/src/__tests__/input.test.ts
@@ -34,6 +34,7 @@ it('parses the inputs.', () => {
     'integrate\nanalyze',
     pathToVerbs,
     'true',
+    'true',
     'true'
   );
 
@@ -47,4 +48,5 @@ it('parses the inputs.', () => {
   );
   expect(inputs.allowOneLiners).toBeTruthy();
   expect(inputs.enforceSignOff).toBeTruthy();
+  expect(inputs.skipBodyCheck).toBeTruthy();
 });

--- a/src/__tests__/inspection.test.ts
+++ b/src/__tests__/inspection.test.ts
@@ -2,7 +2,7 @@ import * as input from '../input';
 import * as inspection from '../inspection';
 
 const defaultInputs: input.Inputs = input
-  .parseInputs('', '', '', '')
+  .parseInputs('', '', '', '', '')
   .mustInputs();
 
 it('reports no errors on correct multi-line message.', () => {
@@ -28,7 +28,7 @@ it('reports no errors on OK multi-line message with allowed one-liners.', () => 
 });
 
 it('reports no errors on OK single-line message with allowed one-liners.', () => {
-  const inputs = input.parseInputs('', '', 'true', '').mustInputs();
+  const inputs = input.parseInputs('', '', 'true', '', '').mustInputs();
 
   const message = 'Change SomeClass to OtherClass';
 
@@ -55,6 +55,25 @@ it('reports too few lines with disallowed one-liners.', () => {
   ]);
 });
 
+it('reports no errors on any message when body check is disabled.', () => {
+  const message =
+    'Change SomeClass to OtherClass\n' +
+    '\n' +
+    'This replaces the SomeClass with OtherClass in all of the module ' +
+    'since Some class was deprecated. This is long message should not ' +
+    'be checked.';
+
+  const inputCheckingBody = input.parseInputs('', '', '', '', '').mustInputs();
+
+  expect(inspection.check(message, inputCheckingBody)).not.toEqual([]);
+
+  const inputNotCheckingBody = input
+    .parseInputs('', '', '', '', 'true')
+    .mustInputs();
+
+  expect(inspection.check(message, inputNotCheckingBody)).toEqual([]);
+});
+
 it('reports missing body with disallowed one-liners.', () => {
   const message = 'Change SomeClass to OtherClass\n\n';
   const errors = inspection.check(message, defaultInputs);
@@ -62,7 +81,7 @@ it('reports missing body with disallowed one-liners.', () => {
 });
 
 it('reports missing body with allowed one-liners.', () => {
-  const inputs = input.parseInputs('', '', 'true', '').mustInputs();
+  const inputs = input.parseInputs('', '', 'true', '', '').mustInputs();
 
   const message = 'Change SomeClass to OtherClass\n';
   const errors = inspection.check(message, inputs);
@@ -148,7 +167,7 @@ it(
   'reports the subject starting with a non-verb ' +
     'with additional verbs given as direct input.',
   () => {
-    const inputs = input.parseInputs('table', '', 'false', '').mustInputs();
+    const inputs = input.parseInputs('table', '', 'false', '', '').mustInputs();
 
     const message =
       'Replaced SomeClass to OtherClass\n' +
@@ -186,6 +205,7 @@ it(
       '/some/path',
       false,
       new Set<string>('table'),
+      false,
       false
     );
 
@@ -217,7 +237,7 @@ it(
 );
 
 it('accepts the subject starting with an additional verb.', () => {
-  const inputs = input.parseInputs('table', '', 'false', '').mustInputs();
+  const inputs = input.parseInputs('table', '', 'false', '', '').mustInputs();
 
   const message = 'Table that for me\n\nThis is a dummy commit.';
   const errors = inspection.check(message, inputs);
@@ -239,7 +259,7 @@ it('reports the subject ending in a dot.', () => {
 });
 
 it('reports an incorrect one-line message with allowed one-liners.', () => {
-  const inputs = input.parseInputs('', '', 'true', '').mustInputs();
+  const inputs = input.parseInputs('', '', 'true', '', '').mustInputs();
 
   const message = 'Change SomeClass to OtherClass.';
 
@@ -414,7 +434,7 @@ The ${long} line is too long.`;
 });
 
 it('accepts the valid body when enforcing the sign-off.', () => {
-  const inputs = input.parseInputs('', '', '', 'true').mustInputs();
+  const inputs = input.parseInputs('', '', '', 'true', '').mustInputs();
 
   const message = `Do something
 
@@ -433,7 +453,7 @@ Signed-off-by: Somebody Else <some@body-else.com>
 });
 
 it('rejects invalid sign-offs.', () => {
-  const inputs = input.parseInputs('', '', '', 'true').mustInputs();
+  const inputs = input.parseInputs('', '', '', 'true', '').mustInputs();
 
   const message = `Do something
 

--- a/src/__tests__/main.test.ts
+++ b/src/__tests__/main.test.ts
@@ -88,6 +88,28 @@ it('considers allow-one-liners.', () => {
   expect(core.setFailed).not.toHaveBeenCalled();
 });
 
+it('considers skip-body-check.', () => {
+  jest
+    .spyOn(commitMessages, 'retrieve')
+    .mockImplementation(() => [
+      'Change SomeClass to OtherClass\n' +
+        '\n' +
+        'Change SomeClass to OtherClass.' +
+        'This replaces the SomeClass with OtherClass in all of the module ' +
+        'since Some class was deprecated.'
+    ]);
+
+  jest.spyOn(core, 'setFailed');
+
+  jest
+    .spyOn(core, 'getInput')
+    .mockImplementation(name => (name === 'skip-body-check' ? 'true' : ''));
+
+  mainImpl.run();
+
+  expect(core.setFailed).not.toHaveBeenCalled();
+});
+
 it('formats properly no error message.', () => {
   jest
     .spyOn(commitMessages, 'retrieve')

--- a/src/input.ts
+++ b/src/input.ts
@@ -4,6 +4,7 @@ export class Inputs {
   public hasAdditionalVerbsInput: boolean;
   public pathToAdditionalVerbs: string;
   public allowOneLiners: boolean;
+  public skipBodyCheck: boolean;
 
   // This is a complete appendix to the whiltelist parsed both from
   // the GitHub action input "additional-verbs" and from the file
@@ -17,13 +18,15 @@ export class Inputs {
     pathToAdditionalVerbs: string,
     allowOneLiners: boolean,
     additionalVerbs: Set<string>,
-    enforceSignOff: boolean
+    enforceSignOff: boolean,
+    skipBodyCheck: boolean
   ) {
     this.hasAdditionalVerbsInput = hasAdditionalVerbsInput;
     this.pathToAdditionalVerbs = pathToAdditionalVerbs;
     this.allowOneLiners = allowOneLiners;
     this.additionalVerbs = additionalVerbs;
     this.enforceSignOff = enforceSignOff;
+    this.skipBodyCheck = skipBodyCheck;
   }
 }
 
@@ -61,7 +64,8 @@ export function parseInputs(
   additionalVerbsInput: string,
   pathToAdditionalVerbsInput: string,
   allowOneLinersInput: string,
-  enforceSignOffInput: string
+  enforceSignOffInput: string,
+  skipBodyCheckInput: string
 ): MaybeInputs {
   const additionalVerbs = new Set<string>();
 
@@ -113,13 +117,26 @@ export function parseInputs(
     );
   }
 
+  const skipBodyCheck: boolean | null = !skipBodyCheckInput
+    ? false
+    : parseBooleanFromString(skipBodyCheckInput);
+
+  if (skipBodyCheck === null) {
+    return new MaybeInputs(
+      null,
+      'Unexpected value for skip-body-check. ' +
+        `Expected either 'true' or 'false', got: ${skipBodyCheckInput}`
+    );
+  }
+
   return new MaybeInputs(
     new Inputs(
       hasAdditionalVerbsInput,
       pathToAdditionalVerbsInput,
       allowOneLiners,
       additionalVerbs,
-      enforceSignOff
+      enforceSignOff,
+      skipBodyCheck
     ),
     null
   );

--- a/src/inspection.ts
+++ b/src/inspection.ts
@@ -320,7 +320,9 @@ export function check(message: string, inputs: input.Inputs): string[] {
 
       errors.push(...checkSubject(subjectBody.subject, inputs));
 
-      errors.push(...checkBody(subjectBody.subject, subjectBody.bodyLines));
+      if (!inputs.skipBodyCheck) {
+        errors.push(...checkBody(subjectBody.subject, subjectBody.bodyLines));
+      }
 
       if (inputs.enforceSignOff) {
         errors.push(...checkSignedOff(subjectBody.bodyLines));

--- a/src/mainImpl.ts
+++ b/src/mainImpl.ts
@@ -24,11 +24,15 @@ function runWithExceptions(): void {
   const enforceSignOffInput =
     core.getInput('enforce-sign-off', {required: false}) ?? '';
 
+  const skipBodyCheckInput =
+    core.getInput('skip-body-check', {required: false}) ?? '';
+
   const maybeInputs = input.parseInputs(
     additionalVerbsInput,
     pathToAdditionalVerbsInput,
     allowOneLinersInput,
-    enforceSignOffInput
+    enforceSignOffInput,
+    skipBodyCheckInput
   );
 
   if (maybeInputs.error !== null) {


### PR DESCRIPTION
Some organizations prefer to use only a subject
line, usually referring to the pull request, as
it provides the full context for the change.

Other reasons for using a subject line-only
include incompatibility with automatic PR bots,
like Renovate. Besides this, most teams today use
some UI to read the PR's message body
(i.e., GitHub), so restricting what can be added
to a PR message can lead to a poor
user experience.

Signed-off-by: Marcos Passos <marcos@croct.com>