### PR TITLE
Release 3.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check
-        uses: mristin/opinionated-commit-message@v2.3.2
+        uses: mristin/opinionated-commit-message@v3
 ```
 
 ## Checked Events
@@ -99,7 +99,7 @@ string in the workflow file. For example:
 ```yaml
     steps:
       - name: Check
-        uses: mristin/opinionated-commit-message@v2
+        uses: mristin/opinionated-commit-message@v3
         with:
           additional-verbs: 'chrusimusi, unit-test'
 ```
@@ -111,7 +111,7 @@ as input:
 ```yaml
     steps:
       - name: Check
-        uses: mristin/opinionated-commit-message@v2
+        uses: mristin/opinionated-commit-message@v3
         with:
           path-to-additional-verbs: 'src/additional-verbs.txt'
 ```
@@ -153,7 +153,7 @@ You can allow one-liner commit messages by setting the flag `allow-one-liners`:
 ```yaml
     steps:
       - name: Check
-        uses: mristin/opinionated-commit-message@v2
+        uses: mristin/opinionated-commit-message@v3
         with:
           allow-one-liners: 'true'
 ```
@@ -219,7 +219,7 @@ We provide an `enforce-sign-off` flag so that you can enforce the sign-off in th
 ```yaml
     steps:
       - name: Check
-        uses: mristin/opinionated-commit-message@v2
+        uses: mristin/opinionated-commit-message@v3
         with:
           enforce-sign-off: 'true'
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mristin/opinionated-commit-message",
-  "version": "2.3.4",
+  "version": "3.0.0",
   "description": "GitHub Action to check commit messages according to an opinionated style",
   "keywords": [
     "github",


### PR DESCRIPTION
Non-breaking changes:

* Make max length of lines configurable (#96)
* Allow skipping message body check (#97)

Breaking change:

* Discontinue local scripts (#98)