### PR TITLE
Specify the exact version in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check
-        uses: mristin/opinionated-commit-message@v3
+        uses: mristin/opinionated-commit-message@v3.0.0
 ```
 
 ## Checked Events
@@ -99,7 +99,7 @@ string in the workflow file. For example:
 ```yaml
     steps:
       - name: Check
-        uses: mristin/opinionated-commit-message@v3
+        uses: mristin/opinionated-commit-message@v3.0.0
         with:
           additional-verbs: 'chrusimusi, unit-test'
 ```
@@ -111,7 +111,7 @@ as input:
 ```yaml
     steps:
       - name: Check
-        uses: mristin/opinionated-commit-message@v3
+        uses: mristin/opinionated-commit-message@v3.0.0
         with:
           path-to-additional-verbs: 'src/additional-verbs.txt'
 ```
@@ -153,7 +153,7 @@ You can allow one-liner commit messages by setting the flag `allow-one-liners`:
 ```yaml
     steps:
       - name: Check
-        uses: mristin/opinionated-commit-message@v3
+        uses: mristin/opinionated-commit-message@v3.0.0
         with:
           allow-one-liners: 'true'
 ```
@@ -219,7 +219,7 @@ We provide an `enforce-sign-off` flag so that you can enforce the sign-off in th
 ```yaml
     steps:
       - name: Check
-        uses: mristin/opinionated-commit-message@v3
+        uses: mristin/opinionated-commit-message@v3.0.0
         with:
           enforce-sign-off: 'true'
 ```


### PR DESCRIPTION
We specified only the major version in the readme which made the clients
fail. Instead, a full version needs to be indicated in the workflow
files.

Fixes #103.