### PR TITLE
Refactor inputs as named parameters

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -32638,15 +32638,15 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.parseVerbs = exports.parseInputs = exports.MaybeInputs = exports.Inputs = void 0;
 const fs_1 = __importDefault(__nccwpck_require__(7147));
 class Inputs {
-    constructor(hasAdditionalVerbsInput, pathToAdditionalVerbs, allowOneLiners, additionalVerbs, maxSubjectLength, maxBodyLineLength, enforceSignOff, skipBodyCheck) {
-        this.hasAdditionalVerbsInput = hasAdditionalVerbsInput;
-        this.pathToAdditionalVerbs = pathToAdditionalVerbs;
-        this.allowOneLiners = allowOneLiners;
-        this.additionalVerbs = additionalVerbs;
-        this.maxSubjectLength = maxSubjectLength;
-        this.maxBodyLineLength = maxBodyLineLength;
-        this.enforceSignOff = enforceSignOff;
-        this.skipBodyCheck = skipBodyCheck;
+    constructor(values) {
+        this.hasAdditionalVerbsInput = values.hasAdditionalVerbsInput;
+        this.pathToAdditionalVerbs = values.pathToAdditionalVerbs;
+        this.allowOneLiners = values.allowOneLiners;
+        this.additionalVerbs = values.additionalVerbs;
+        this.maxSubjectLength = values.maxSubjectLength;
+        this.maxBodyLineLength = values.maxBodyLineLength;
+        this.enforceSignOff = values.enforceSignOff;
+        this.skipBodyCheck = values.skipBodyCheck;
     }
 }
 exports.Inputs = Inputs;
@@ -32670,7 +32670,8 @@ class MaybeInputs {
     }
 }
 exports.MaybeInputs = MaybeInputs;
-function parseInputs(additionalVerbsInput, pathToAdditionalVerbsInput, allowOneLinersInput, maxSubjectLengthInput, maxBodyLineLengthInput, enforceSignOffInput, skipBodyCheckInput) {
+function parseInputs(rawInputs) {
+    const { additionalVerbsInput = '', pathToAdditionalVerbsInput = '', allowOneLinersInput = '', maxSubjectLengthInput = '', maxBodyLineLengthInput = '', enforceSignOffInput = '', skipBodyCheckInput = '' } = rawInputs;
     const additionalVerbs = new Set();
     const hasAdditionalVerbsInput = additionalVerbsInput.length > 0;
     if (additionalVerbsInput) {
@@ -32723,7 +32724,16 @@ function parseInputs(additionalVerbsInput, pathToAdditionalVerbsInput, allowOneL
         return new MaybeInputs(null, 'Unexpected value for skip-body-check. ' +
             `Expected either 'true' or 'false', got: ${skipBodyCheckInput}`);
     }
-    return new MaybeInputs(new Inputs(hasAdditionalVerbsInput, pathToAdditionalVerbsInput, allowOneLiners, additionalVerbs, maxSubjectLength, maxBodyLineLength, enforceSignOff, skipBodyCheck), null);
+    return new MaybeInputs(new Inputs({
+        hasAdditionalVerbsInput,
+        pathToAdditionalVerbs: pathToAdditionalVerbsInput,
+        allowOneLiners,
+        additionalVerbs,
+        maxSubjectLength,
+        maxBodyLineLength,
+        enforceSignOff,
+        skipBodyCheck
+    }), null);
 }
 exports.parseInputs = parseInputs;
 function parseVerbs(text) {
@@ -33103,19 +33113,40 @@ const inspection = __importStar(__nccwpck_require__(7647));
 const represent = __importStar(__nccwpck_require__(4478));
 const input = __importStar(__nccwpck_require__(6747));
 function runWithExceptions() {
-    var _a, _b, _c, _d, _e, _f, _g;
     const messages = commitMessages.retrieve();
     ////
     // Parse inputs
     ////
-    const additionalVerbsInput = (_a = core.getInput('additional-verbs', { required: false })) !== null && _a !== void 0 ? _a : '';
-    const pathToAdditionalVerbsInput = (_b = core.getInput('path-to-additional-verbs', { required: false })) !== null && _b !== void 0 ? _b : '';
-    const allowOneLinersInput = (_c = core.getInput('allow-one-liners', { required: false })) !== null && _c !== void 0 ? _c : '';
-    const maxSubjectLengthInput = (_d = core.getInput('max-subject-line-length', { required: false })) !== null && _d !== void 0 ? _d : '';
-    const maxBodyLineLengthInput = (_e = core.getInput('max-body-line-length', { required: false })) !== null && _e !== void 0 ? _e : '';
-    const enforceSignOffInput = (_f = core.getInput('enforce-sign-off', { required: false })) !== null && _f !== void 0 ? _f : '';
-    const skipBodyCheckInput = (_g = core.getInput('skip-body-check', { required: false })) !== null && _g !== void 0 ? _g : '';
-    const maybeInputs = input.parseInputs(additionalVerbsInput, pathToAdditionalVerbsInput, allowOneLinersInput, maxSubjectLengthInput, maxBodyLineLengthInput, enforceSignOffInput, skipBodyCheckInput);
+    const additionalVerbsInput = core.getInput('additional-verbs', {
+        required: false
+    });
+    const pathToAdditionalVerbsInput = core.getInput('path-to-additional-verbs', {
+        required: false
+    });
+    const allowOneLinersInput = core.getInput('allow-one-liners', {
+        required: false
+    });
+    const maxSubjectLengthInput = core.getInput('max-subject-line-length', {
+        required: false
+    });
+    const maxBodyLineLengthInput = core.getInput('max-body-line-length', {
+        required: false
+    });
+    const enforceSignOffInput = core.getInput('enforce-sign-off', {
+        required: false
+    });
+    const skipBodyCheckInput = core.getInput('skip-body-check', {
+        required: false
+    });
+    const maybeInputs = input.parseInputs({
+        additionalVerbsInput,
+        pathToAdditionalVerbsInput,
+        allowOneLinersInput,
+        maxSubjectLengthInput,
+        maxBodyLineLengthInput,
+        enforceSignOffInput,
+        skipBodyCheckInput
+    });
     if (maybeInputs.error !== null) {
         core.error(maybeInputs.error);
         core.setFailed(maybeInputs.error);

--- a/src/__tests__/input.test.ts
+++ b/src/__tests__/input.test.ts
@@ -30,15 +30,15 @@ it('parses the inputs.', () => {
     throw new Error(`Unexpected readFileSync in the unit test from: ${path}`);
   };
 
-  const maybeInputs = input.parseInputs(
-    'integrate\nanalyze',
-    pathToVerbs,
-    'true',
-    '90',
-    '100',
-    'true',
-    'true'
-  );
+  const maybeInputs = input.parseInputs({
+    additionalVerbsInput: 'integrate\nanalyze',
+    pathToAdditionalVerbsInput: pathToVerbs,
+    allowOneLinersInput: 'true',
+    maxSubjectLengthInput: '90',
+    maxBodyLineLengthInput: '100',
+    enforceSignOffInput: 'true',
+    skipBodyCheckInput: 'true',
+  });
 
   expect(maybeInputs.error).toBeNull();
 

--- a/src/__tests__/inspection.test.ts
+++ b/src/__tests__/inspection.test.ts
@@ -2,7 +2,7 @@ import * as input from '../input';
 import * as inspection from '../inspection';
 
 const defaultInputs: input.Inputs = input
-  .parseInputs('', '', '', '', '', '', '')
+  .parseInputs({})
   .mustInputs();
 
 it('reports no errors on correct multi-line message.', () => {
@@ -28,7 +28,9 @@ it('reports no errors on OK multi-line message with allowed one-liners.', () => 
 });
 
 it('reports no errors on OK single-line message with allowed one-liners.', () => {
-  const inputs = input.parseInputs('', '', 'true', '', '', '', '').mustInputs();
+  const inputs = input
+    .parseInputs({allowOneLinersInput: 'true'})
+    .mustInputs();
 
   const message = 'Change SomeClass to OtherClass';
 
@@ -64,13 +66,13 @@ it('reports no errors on any message when body check is disabled.', () => {
     'be checked.';
 
   const inputCheckingBody = input
-    .parseInputs('', '', '', '', '', '', '')
+    .parseInputs({skipBodyCheckInput: 'false'})
     .mustInputs();
 
   expect(inspection.check(message, inputCheckingBody)).not.toEqual([]);
 
   const inputNotCheckingBody = input
-    .parseInputs('', '', '', '', '', '', 'true')
+    .parseInputs({skipBodyCheckInput: 'true'})
     .mustInputs();
 
   expect(inspection.check(message, inputNotCheckingBody)).toEqual([]);
@@ -83,7 +85,9 @@ it('reports missing body with disallowed one-liners.', () => {
 });
 
 it('reports missing body with allowed one-liners.', () => {
-  const inputs = input.parseInputs('', '', 'true', '', '', '', '').mustInputs();
+  const inputs = input
+    .parseInputs({allowOneLinersInput: 'true'})
+    .mustInputs();
 
   const message = 'Change SomeClass to OtherClass\n';
   const errors = inspection.check(message, inputs);
@@ -170,7 +174,10 @@ it(
     'with additional verbs given as direct input.',
   () => {
     const inputs = input
-      .parseInputs('table', '', 'false', '', '', '', '')
+      .parseInputs({
+        additionalVerbsInput: 'table',
+        allowOneLinersInput: 'false'
+      })
       .mustInputs();
 
     const message =
@@ -204,16 +211,16 @@ it(
   'reports the subject starting with a non-verb ' +
     'with additional verbs given in a path.',
   () => {
-    const inputs = new input.Inputs(
-      false,
-      '/some/path',
-      false,
-      new Set<string>('table'),
-      50,
-      72,
-      false,
-      false
-    );
+    const inputs = new input.Inputs({
+      hasAdditionalVerbsInput: false,
+      pathToAdditionalVerbs: '/some/path',
+      allowOneLiners: false,
+      additionalVerbs: new Set<string>('table'),
+      maxSubjectLength: 50,
+      maxBodyLineLength: 72,
+      enforceSignOff: false,
+      skipBodyCheck: false,
+    });
 
     const message =
       'Replaced SomeClass to OtherClass\n' +
@@ -244,7 +251,10 @@ it(
 
 it('accepts the subject starting with an additional verb.', () => {
   const inputs = input
-    .parseInputs('table', '', 'false', '', '', '', '')
+    .parseInputs({
+      additionalVerbsInput: 'table',
+      allowOneLinersInput: 'false',
+    })
     .mustInputs();
 
   const message = 'Table that for me\n\nThis is a dummy commit.';
@@ -267,7 +277,9 @@ it('reports the subject ending in a dot.', () => {
 });
 
 it('reports an incorrect one-line message with allowed one-liners.', () => {
-  const inputs = input.parseInputs('', '', 'true', '', '', '', '').mustInputs();
+  const inputs = input
+    .parseInputs({allowOneLinersInput: 'true'})
+    .mustInputs();
 
   const message = 'Change SomeClass to OtherClass.';
 
@@ -300,7 +312,9 @@ it('reports too long a subject line with custom max length.', () => {
     'This replaces the SomeClass with OtherClass in all of the module\n' +
     'since Some class was deprecated.';
 
-  const inputs = input.parseInputs('', '', '', '60', '', '', '').mustInputs();
+  const inputs = input
+    .parseInputs({maxSubjectLengthInput: '60'})
+    .mustInputs();
 
   const errors = inspection.check(message, inputs);
   expect(errors).toEqual([
@@ -334,7 +348,9 @@ it('reports too long a body line with custom max length.', () => {
     'This replaces the SomeClass with OtherClass in all of the module ' +
     'since Some class was deprecated.';
 
-  const inputs = input.parseInputs('', '', '', '', '90', '', '').mustInputs();
+  const inputs = input
+    .parseInputs({maxBodyLineLengthInput: '90'})
+    .mustInputs();
 
   const errors = inspection.check(message, inputs);
   expect(errors).toEqual([
@@ -493,7 +509,9 @@ The ${long} line is too long.`;
 });
 
 it('accepts the valid body when enforcing the sign-off.', () => {
-  const inputs = input.parseInputs('', '', '', '', '', 'true', '').mustInputs();
+  const inputs = input
+    .parseInputs({enforceSignOffInput: 'true'})
+    .mustInputs();
 
   const message = `Do something
 
@@ -512,7 +530,9 @@ Signed-off-by: Somebody Else <some@body-else.com>
 });
 
 it('rejects invalid sign-offs.', () => {
-  const inputs = input.parseInputs('', '', '', '', '', 'true', '').mustInputs();
+  const inputs = input
+    .parseInputs({enforceSignOffInput: 'true'})
+    .mustInputs();
 
   const message = `Do something
 

--- a/src/input.ts
+++ b/src/input.ts
@@ -1,6 +1,17 @@
 import fs from 'fs';
 
-export class Inputs {
+interface InputValues {
+  hasAdditionalVerbsInput: boolean;
+  pathToAdditionalVerbs: string;
+  allowOneLiners: boolean;
+  additionalVerbs: Set<string>;
+  maxSubjectLength: number;
+  maxBodyLineLength: number;
+  enforceSignOff: boolean;
+  skipBodyCheck: boolean;
+}
+
+export class Inputs implements InputValues {
   public hasAdditionalVerbsInput: boolean;
   public pathToAdditionalVerbs: string;
   public allowOneLiners: boolean;
@@ -8,31 +19,22 @@ export class Inputs {
   public maxBodyLineLength: number;
   public skipBodyCheck: boolean;
 
-  // This is a complete appendix to the whiltelist parsed both from
+  // This is a complete appendix to the whitelist parsed both from
   // the GitHub action input "additional-verbs" and from the file
   // specified by the input "path-to-additional-verbs".
   additionalVerbs: Set<string>;
 
   public enforceSignOff: boolean;
 
-  constructor(
-    hasAdditionalVerbsInput: boolean,
-    pathToAdditionalVerbs: string,
-    allowOneLiners: boolean,
-    additionalVerbs: Set<string>,
-    maxSubjectLength: number,
-    maxBodyLineLength: number,
-    enforceSignOff: boolean,
-    skipBodyCheck: boolean
-  ) {
-    this.hasAdditionalVerbsInput = hasAdditionalVerbsInput;
-    this.pathToAdditionalVerbs = pathToAdditionalVerbs;
-    this.allowOneLiners = allowOneLiners;
-    this.additionalVerbs = additionalVerbs;
-    this.maxSubjectLength = maxSubjectLength;
-    this.maxBodyLineLength = maxBodyLineLength;
-    this.enforceSignOff = enforceSignOff;
-    this.skipBodyCheck = skipBodyCheck;
+  constructor(values: InputValues) {
+    this.hasAdditionalVerbsInput = values.hasAdditionalVerbsInput;
+    this.pathToAdditionalVerbs = values.pathToAdditionalVerbs;
+    this.allowOneLiners = values.allowOneLiners;
+    this.additionalVerbs = values.additionalVerbs;
+    this.maxSubjectLength = values.maxSubjectLength;
+    this.maxBodyLineLength = values.maxBodyLineLength;
+    this.enforceSignOff = values.enforceSignOff;
+    this.skipBodyCheck = values.skipBodyCheck;
   }
 }
 
@@ -66,15 +68,27 @@ export class MaybeInputs {
   }
 }
 
-export function parseInputs(
-  additionalVerbsInput: string,
-  pathToAdditionalVerbsInput: string,
-  allowOneLinersInput: string,
-  maxSubjectLengthInput: string,
-  maxBodyLineLengthInput: string,
-  enforceSignOffInput: string,
-  skipBodyCheckInput: string
-): MaybeInputs {
+interface RawInputs {
+  additionalVerbsInput?: string;
+  pathToAdditionalVerbsInput?: string;
+  allowOneLinersInput?: string;
+  maxSubjectLengthInput?: string;
+  maxBodyLineLengthInput?: string;
+  enforceSignOffInput?: string;
+  skipBodyCheckInput?: string;
+}
+
+export function parseInputs(rawInputs: RawInputs): MaybeInputs {
+  const {
+    additionalVerbsInput = '',
+    pathToAdditionalVerbsInput = '',
+    allowOneLinersInput = '',
+    maxSubjectLengthInput = '',
+    maxBodyLineLengthInput = '',
+    enforceSignOffInput = '',
+    skipBodyCheckInput = ''
+  } = rawInputs;
+
   const additionalVerbs = new Set<string>();
 
   const hasAdditionalVerbsInput = additionalVerbsInput.length > 0;
@@ -162,16 +176,16 @@ export function parseInputs(
   }
 
   return new MaybeInputs(
-    new Inputs(
+    new Inputs({
       hasAdditionalVerbsInput,
-      pathToAdditionalVerbsInput,
+      pathToAdditionalVerbs: pathToAdditionalVerbsInput,
       allowOneLiners,
       additionalVerbs,
       maxSubjectLength,
       maxBodyLineLength,
       enforceSignOff,
       skipBodyCheck
-    ),
+    }),
     null
   );
 }

--- a/src/mainImpl.ts
+++ b/src/mainImpl.ts
@@ -12,28 +12,35 @@ function runWithExceptions(): void {
   // Parse inputs
   ////
 
-  const additionalVerbsInput =
-    core.getInput('additional-verbs', {required: false}) ?? '';
+  const additionalVerbsInput = core.getInput('additional-verbs', {
+    required: false
+  });
 
-  const pathToAdditionalVerbsInput =
-    core.getInput('path-to-additional-verbs', {required: false}) ?? '';
+  const pathToAdditionalVerbsInput = core.getInput('path-to-additional-verbs', {
+    required: false
+  });
 
-  const allowOneLinersInput =
-    core.getInput('allow-one-liners', {required: false}) ?? '';
+  const allowOneLinersInput = core.getInput('allow-one-liners', {
+    required: false
+  });
 
-  const maxSubjectLengthInput =
-    core.getInput('max-subject-line-length', {required: false}) ?? '';
+  const maxSubjectLengthInput = core.getInput('max-subject-line-length', {
+    required: false
+  });
 
-  const maxBodyLineLengthInput =
-    core.getInput('max-body-line-length', {required: false}) ?? '';
+  const maxBodyLineLengthInput = core.getInput('max-body-line-length', {
+    required: false
+  });
 
-  const enforceSignOffInput =
-    core.getInput('enforce-sign-off', {required: false}) ?? '';
+  const enforceSignOffInput = core.getInput('enforce-sign-off', {
+    required: false
+  });
 
-  const skipBodyCheckInput =
-    core.getInput('skip-body-check', {required: false}) ?? '';
+  const skipBodyCheckInput = core.getInput('skip-body-check', {
+    required: false
+  });
 
-  const maybeInputs = input.parseInputs(
+  const maybeInputs = input.parseInputs({
     additionalVerbsInput,
     pathToAdditionalVerbsInput,
     allowOneLinersInput,
@@ -41,7 +48,7 @@ function runWithExceptions(): void {
     maxBodyLineLengthInput,
     enforceSignOffInput,
     skipBodyCheckInput
-  );
+  });
 
   if (maybeInputs.error !== null) {
     core.error(maybeInputs.error);


### PR DESCRIPTION
We change the arguments of `parseInputs` and the `Inputs` constructor
to receive an object with named arguments.

This allows for adding new properties without breaking existing tests
and more clarity on the inputs used on each test.