### PR TITLE
Add support for ignored patterns

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -40,6 +40,16 @@ inputs:
     description: 'If set to "true", validate commits in pull requests instead of the pull request body'
     required: false
     default: ''
+  ignore-merge-commits:
+    description: 'If set to "false", merge commits will not be ignored.'
+    required: false
+    default: 'true'
+  ignore-patterns:
+    description: >-
+      Pattern to ignore in commit messages. One pattern per line.
+      Patterns are matched against the whole commit message as regular expressions without any flags.
+    required: false
+    default: ''
   github-token:
     description: 'GitHub token'
     required: false

--- a/src/__tests__/input.test.ts
+++ b/src/__tests__/input.test.ts
@@ -39,6 +39,11 @@ it('parses the inputs.', () => {
     enforceSignOffInput: 'true',
     validatePullRequestCommitsInput: 'true',
     skipBodyCheckInput: 'true',
+    ignoreMergeCommitsInput: 'false',
+    ignorePatternsInput: `
+    ^Some pattern$
+    Another pattern
+    `
   });
 
   expect(maybeInputs.error).toBeNull();
@@ -55,4 +60,9 @@ it('parses the inputs.', () => {
   expect(inputs.enforceSignOff).toBeTruthy();
   expect(inputs.validatePullRequestCommits).toBeTruthy();
   expect(inputs.skipBodyCheck).toBeTruthy();
+  expect(inputs.ignoreMergeCommits).toBeFalsy();
+  expect(inputs.ignorePatterns).toEqual([
+    /^Some pattern$/,
+    /Another pattern/
+  ]);
 });

--- a/src/mainImpl.ts
+++ b/src/mainImpl.ts
@@ -44,6 +44,14 @@ async function runWithExceptions(): Promise<void> {
     required: false,
   });
 
+  const ignoreMergeCommitsInput = core.getInput('ignore-merge-commits', {
+    required: false,
+  });
+
+  const ignorePatternsInput = core.getInput('ignore-patterns', {
+    required: false,
+  });
+
   const maybeInputs = input.parseInputs({
     additionalVerbsInput,
     pathToAdditionalVerbsInput,
@@ -53,6 +61,8 @@ async function runWithExceptions(): Promise<void> {
     enforceSignOffInput,
     validatePullRequestCommitsInput,
     skipBodyCheckInput,
+    ignoreMergeCommitsInput,
+    ignorePatternsInput,
   });
 
   if (maybeInputs.error !== null) {


### PR DESCRIPTION
There was already logic to ignore merge commits,
but it was using a very restricted regular expression.


This PR:
- Improve the existing merge commit detection.
- Allow users to disable merge commit detection.
- Allow users to provide custom patterns to ignore

Related issues:
- Closes #110 