### PR TITLE
Add min-body-length option

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -24,6 +24,10 @@ inputs:
     description: 'Maximum length of the commit subject line'
     required: false
     default: ''
+  min-body-length:
+    description: 'Minimum length of the body of the commit message'
+    required: false
+    default: ''
   max-body-line-length:
     description: 'Maximum length of a line in the body of the commit message'
     required: false

--- a/src/__tests__/input.test.ts
+++ b/src/__tests__/input.test.ts
@@ -35,6 +35,7 @@ it('parses the inputs.', () => {
     pathToAdditionalVerbsInput: pathToVerbs,
     allowOneLinersInput: 'true',
     maxSubjectLengthInput: '90',
+    minBodyLengthInput: '120',
     maxBodyLineLengthInput: '100',
     enforceSignOffInput: 'true',
     validatePullRequestCommitsInput: 'true',
@@ -56,6 +57,7 @@ it('parses the inputs.', () => {
   );
   expect(inputs.allowOneLiners).toBeTruthy();
   expect(inputs.maxSubjectLength).toEqual(90);
+  expect(inputs.minBodyLength).toEqual(120);
   expect(inputs.maxBodyLineLength).toEqual(100);
   expect(inputs.enforceSignOff).toBeTruthy();
   expect(inputs.validatePullRequestCommits).toBeTruthy();

--- a/src/__tests__/inspection.test.ts
+++ b/src/__tests__/inspection.test.ts
@@ -212,6 +212,7 @@ it(
       allowOneLiners: false,
       additionalVerbs: new Set<string>('table'),
       maxSubjectLength: 50,
+      minBodyLength: 0,
       maxBodyLineLength: 72,
       enforceSignOff: false,
       validatePullRequestCommits: false,
@@ -316,6 +317,47 @@ it('reports too long a subject line with custom max length.', () => {
       `(got: 70, JSON: "Change SomeClass to OtherClass in order to handle upstream deprecation").` +
       'Please shorten the subject to make it more succinct.',
   ]);
+});
+
+it('reports too short a body length.', () => {
+  const message =
+    'Change SomeClass to OtherClass\n' +
+    '\n' +
+    'This replaces the SomeClass with OtherClass in all of the module\n' +
+    'since Some class was deprecated.';
+
+  const inputs = input.parseInputs({minBodyLengthInput: '100'}).mustInputs();
+
+  const errors = inspection.check(message, inputs);
+  expect(errors).toEqual([
+    `The body must contain at least 100 characters. ` +
+    `The body contains 97 characters.`
+  ]);
+});
+
+it('accepts a body length.', () => {
+  const message =
+    'Change SomeClass to OtherClass\n' +
+    '\n' +
+    'This replaces the SomeClass with OtherClass in all of the module\n' +
+    'since Some class was deprecated.';
+
+  const inputs = input.parseInputs({minBodyLengthInput: '97'}).mustInputs();
+
+  const errors = inspection.check(message, inputs);
+  expect(errors).toEqual([]);
+});
+
+it('accepts a no minimum body length.', () => {
+  const message =
+    'Change SomeClass to OtherClass\n' +
+    '\n' +
+    'This changes SomeClass to OtherClass';
+
+  const inputs = input.parseInputs({}).mustInputs();
+
+  const errors = inspection.check(message, inputs);
+  expect(errors).toEqual([]);
 });
 
 it('reports too long a body line.', () => {

--- a/src/input.ts
+++ b/src/input.ts
@@ -6,6 +6,7 @@ interface InputValues {
   allowOneLiners: boolean;
   additionalVerbs: Set<string>;
   maxSubjectLength: number;
+  minBodyLength: number;
   maxBodyLineLength: number;
   enforceSignOff: boolean;
   validatePullRequestCommits: boolean;
@@ -19,6 +20,7 @@ export class Inputs implements InputValues {
   public pathToAdditionalVerbs: string;
   public allowOneLiners: boolean;
   public maxSubjectLength: number;
+  public minBodyLength: number;
   public maxBodyLineLength: number;
   public skipBodyCheck: boolean;
   public validatePullRequestCommits: boolean;
@@ -38,6 +40,7 @@ export class Inputs implements InputValues {
     this.allowOneLiners = values.allowOneLiners;
     this.additionalVerbs = values.additionalVerbs;
     this.maxSubjectLength = values.maxSubjectLength;
+    this.minBodyLength = values.minBodyLength;
     this.maxBodyLineLength = values.maxBodyLineLength;
     this.enforceSignOff = values.enforceSignOff;
     this.validatePullRequestCommits = values.validatePullRequestCommits;
@@ -82,6 +85,7 @@ interface RawInputs {
   pathToAdditionalVerbsInput?: string;
   allowOneLinersInput?: string;
   maxSubjectLengthInput?: string;
+  minBodyLengthInput?: string;
   maxBodyLineLengthInput?: string;
   enforceSignOffInput?: string;
   validatePullRequestCommitsInput?: string;
@@ -118,6 +122,7 @@ export function parseInputs(rawInputs: RawInputs): MaybeInputs {
     pathToAdditionalVerbsInput = '',
     allowOneLinersInput = '',
     maxSubjectLengthInput = '',
+    minBodyLengthInput = '',
     maxBodyLineLengthInput = '',
     enforceSignOffInput = '',
     validatePullRequestCommitsInput = '',
@@ -173,6 +178,18 @@ export function parseInputs(rawInputs: RawInputs): MaybeInputs {
       null,
       'Unexpected value for max-subject-line-length. ' +
         `Expected a number or nothing, got ${maxSubjectLengthInput}`,
+    );
+  }
+
+  const minBodyLength: number = !minBodyLengthInput
+    ? 0
+    : parseInt(minBodyLengthInput, 10);
+
+  if (Number.isNaN(minBodyLength)) {
+    return new MaybeInputs(
+      null,
+      'Unexpected value for min-body-length. ' +
+        `Expected a number or nothing, got ${minBodyLengthInput}`,
     );
   }
 
@@ -253,6 +270,7 @@ export function parseInputs(rawInputs: RawInputs): MaybeInputs {
       allowOneLiners,
       additionalVerbs,
       maxSubjectLength,
+      minBodyLength,
       maxBodyLineLength,
       enforceSignOff,
       validatePullRequestCommits,

--- a/src/inspection.ts
+++ b/src/inspection.ts
@@ -228,6 +228,19 @@ function checkBody(
     return errors;
   }
 
+  // Minimum character body length
+  if (inputs.minBodyLength) {
+    const bodyLength = bodyLines.join(' ').length;
+
+    if (bodyLength < inputs.minBodyLength) {
+        errors.push(
+          `The body must contain at least ${inputs.minBodyLength} characters. ` +
+          `The body contains ${bodyLength} characters.`,
+        );
+        return errors;
+    }
+  }
+
   for (const [i, line] of bodyLines.entries()) {
     if (urlLineRe.test(line) || linkDefinitionRe.test(line)) {
       continue;

--- a/src/mainImpl.ts
+++ b/src/mainImpl.ts
@@ -25,6 +25,10 @@ async function runWithExceptions(): Promise<void> {
     required: false,
   });
 
+  const minBodyLengthInput = core.getInput('min-body-length', {
+    required: false,
+  });
+
   const maxBodyLineLengthInput = core.getInput('max-body-line-length', {
     required: false,
   });
@@ -57,6 +61,7 @@ async function runWithExceptions(): Promise<void> {
     pathToAdditionalVerbsInput,
     allowOneLinersInput,
     maxSubjectLengthInput,
+    minBodyLengthInput,
     maxBodyLineLengthInput,
     enforceSignOffInput,
     validatePullRequestCommitsInput,


### PR DESCRIPTION
When set an error will be emitted if the body does not contain enough characters. This is useful to require commit bodies with more information, like impact, motivation, approach, testing results, new behavior, *etc.*

Default: no minimum. Suggested: at least 150.

Fixes #136.