### PR TITLE
Update Node.js to v24

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -2,7 +2,7 @@ name: 'Opinionated-commit-message'
 description: 'Check commit messages according to an opinionated style'
 author: 'Marko Ristin'
 runs:
-  using: node20
+  using: node24
   main: dist/index.js
 branding:
   icon: 'check'


### PR DESCRIPTION
Warning from GitHub:
Node.js 20 actions are deprecated.
The following actions are running on Node.js 20 and may not work as expected. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026.

Node.js 20 will be removed from the runner on September 16th, 2026.

For more information see:
https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/